### PR TITLE
Fix CI image cleanup

### DIFF
--- a/.github/scripts/cleanup-e2e-images.sh
+++ b/.github/scripts/cleanup-e2e-images.sh
@@ -37,7 +37,7 @@ for suffix in "${PACKAGE_SUFFIXES[@]}"; do
   
   if [ "$deleted" = "true" ]; then
     echo "✅ Deleted: ${package_name}"
-    ((DELETED++))
+    DELETED=$((DELETED + 1))
   else
     # Check if it's a 404 (package doesn't exist) or a real error
     if echo "$output" | grep -qi "not found.*404\|package not found"; then

--- a/.github/scripts/cleanup-e2e-images.sh
+++ b/.github/scripts/cleanup-e2e-images.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Knative Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eEuo pipefail
+
+# Delete all test run-specific images to avoid accumulation
+# Package names are like: knative-serving-wasm/e2e-6/runner
+
+RUN_ID="${1:?Usage: $0 <run_id> <owner>}"
+OWNER="${2:?Usage: $0 <run_id> <owner>}"
+PATTERN="e2e-${RUN_ID}"
+FAILED=0
+
+echo "Deleting packages containing: ${PATTERN}"
+
+# List packages matching the pattern and delete them
+# Packages are user-scoped but linked to repository, use /users/{owner}/packages
+PACKAGES=$(gh api "/users/${OWNER}/packages?package_type=container" \
+  --jq ".[] | select(.name | contains(\"${PATTERN}\")) | .name") || {
+  echo "::error::Failed to list packages from GitHub API"
+  exit 1
+}
+
+if [ -z "$PACKAGES" ]; then
+  echo "No packages found matching pattern: ${PATTERN}"
+  exit 0
+fi
+
+echo "Found packages to delete:"
+echo "$PACKAGES"
+
+while IFS= read -r package_name; do
+  # URL-encode the package name (slashes become %2F)
+  encoded_name=$(printf '%s' "$package_name" | jq -sRr @uri)
+  echo "Deleting package: ${package_name}"
+  if ! gh api --method DELETE "/users/${OWNER}/packages/container/${encoded_name}"; then
+    echo "::error::Failed to delete package: ${package_name}"
+    FAILED=1
+  fi
+done <<< "$PACKAGES"
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "::error::Some packages failed to delete"
+  exit 1
+fi
+
+echo "✅ Cleanup complete - deleted $(echo "$PACKAGES" | wc -l) package(s)"

--- a/.github/scripts/cleanup-e2e-images.sh
+++ b/.github/scripts/cleanup-e2e-images.sh
@@ -6,43 +6,57 @@ set -eEuo pipefail
 
 # Delete all test run-specific images to avoid accumulation
 # Package names are like: knative-serving-wasm/e2e-6/runner
+# Known package suffixes from the e2e tests
 
-RUN_ID="${1:?Usage: $0 <run_id> <owner>}"
-OWNER="${2:?Usage: $0 <run_id> <owner>}"
+RUN_ID="${1:?Usage: $0 <run_id> <owner> <repo>}"
+OWNER="${2:?Usage: $0 <run_id> <owner> <repo>}"
+REPO="${3:?Usage: $0 <run_id> <owner> <repo>}"
 PATTERN="e2e-${RUN_ID}"
 FAILED=0
+DELETED=0
 
 echo "Deleting packages containing: ${PATTERN}"
 
-# List packages matching the pattern and delete them
-# Packages are user-scoped but linked to repository, use /users/{owner}/packages
-PACKAGES=$(gh api "/users/${OWNER}/packages?package_type=container" \
-  --jq ".[] | select(.name | contains(\"${PATTERN}\")) | .name") || {
-  echo "::error::Failed to list packages from GitHub API"
-  exit 1
-}
+# Known package names from e2e tests
+# These are the packages created during e2e test runs
+PACKAGE_SUFFIXES=(
+  "controller"
+  "runner"
+  "example/reverse-text"
+  "example/http-fetch"
+)
 
-if [ -z "$PACKAGES" ]; then
-  echo "No packages found matching pattern: ${PATTERN}"
-  exit 0
-fi
-
-echo "Found packages to delete:"
-echo "$PACKAGES"
-
-while IFS= read -r package_name; do
-  # URL-encode the package name (slashes become %2F)
+for suffix in "${PACKAGE_SUFFIXES[@]}"; do
+  package_name="${REPO}/${PATTERN}/${suffix}"
   encoded_name=$(printf '%s' "$package_name" | jq -sRr @uri)
-  echo "Deleting package: ${package_name}"
-  if ! gh api --method DELETE "/users/${OWNER}/packages/container/${encoded_name}"; then
-    echo "::error::Failed to delete package: ${package_name}"
-    FAILED=1
+  
+  echo "Attempting to delete package: ${package_name}"
+  
+  # Try to delete the package
+  output=$(gh api --method DELETE "/users/${OWNER}/packages/container/${encoded_name}" 2>&1) && deleted=true || deleted=false
+  
+  if [ "$deleted" = "true" ]; then
+    echo "✅ Deleted: ${package_name}"
+    ((DELETED++))
+  else
+    # Check if it's a 404 (package doesn't exist) or a real error
+    if echo "$output" | grep -qi "not found.*404\|package not found"; then
+      echo "::warning::Package not found (may not have been created): ${package_name}"
+    else
+      echo "::error::Failed to delete package: ${package_name}"
+      echo "::error::Error: ${output}"
+      FAILED=1
+    fi
   fi
-done <<< "$PACKAGES"
+done
 
 if [ "$FAILED" -eq 1 ]; then
   echo "::error::Some packages failed to delete"
   exit 1
 fi
 
-echo "✅ Cleanup complete - deleted $(echo "$PACKAGES" | wc -l) package(s)"
+if [ "$DELETED" -eq 0 ]; then
+  echo "::warning::No packages were deleted (they may not have been created yet)"
+fi
+
+echo "✅ Cleanup complete - deleted ${DELETED} package(s)"

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -61,22 +61,23 @@ jobs:
         ARTIFACTS: ${{ github.workspace }}/artifacts
 
     - name: Delete e2e images from ghcr.io
-      if: always() && github.event_name == 'pull_request'
+      if: always()
       continue-on-error: true
       run: |
         set -o pipefail
         
-        # Delete all PR-specific images to avoid accumulation
+        # Delete all test run-specific images to avoid accumulation
         # Package names are like: knative-serving-wasm/e2e-6/runner
         RUN_ID=${{ github.event.pull_request.number || github.run_id }}
         PATTERN="e2e-${RUN_ID}"
         FAILED=0
+        OWNER="${{ github.repository_owner }}"
         
         echo "Deleting packages containing: ${PATTERN}"
         
-        # List packages matching the PR pattern and delete them
-        # Package names contain slashes, so we need URL-encoding for the delete API
-        PACKAGES=$(gh api "/user/packages?package_type=container" --jq ".[] | select(.name | contains(\"${PATTERN}\")) | .name" 2>&1) || {
+        # List packages matching the pattern and delete them
+        # Packages are user-scoped but linked to repository, use /users/{owner}/packages
+        PACKAGES=$(gh api "/users/${OWNER}/packages?package_type=container" --jq ".[] | select(.name | contains(\"${PATTERN}\")) | .name" 2>&1) || {
           echo "::warning::Failed to list packages: ${PACKAGES}"
           exit 1
         }
@@ -90,7 +91,7 @@ jobs:
           # URL-encode the package name (slashes become %2F)
           encoded_name=$(printf '%s' "$package_name" | jq -sRr @uri)
           echo "Deleting package: ${package_name}"
-          if ! gh api --method DELETE "/user/packages/container/${encoded_name}" 2>&1; then
+          if ! gh api --method DELETE "/users/${OWNER}/packages/container/${encoded_name}" 2>&1; then
             echo "::warning::Failed to delete package: ${package_name}"
             FAILED=1
           fi

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -65,7 +65,8 @@ jobs:
       run: |
         .github/scripts/cleanup-e2e-images.sh \
           "${{ github.event.pull_request.number || github.run_id }}" \
-          "${{ github.repository_owner }}"
+          "${{ github.repository_owner }}" \
+          "${{ github.event.repository.name }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -62,47 +62,10 @@ jobs:
 
     - name: Delete e2e images from ghcr.io
       if: always()
-      continue-on-error: true
       run: |
-        set -o pipefail
-        
-        # Delete all test run-specific images to avoid accumulation
-        # Package names are like: knative-serving-wasm/e2e-6/runner
-        RUN_ID=${{ github.event.pull_request.number || github.run_id }}
-        PATTERN="e2e-${RUN_ID}"
-        FAILED=0
-        OWNER="${{ github.repository_owner }}"
-        
-        echo "Deleting packages containing: ${PATTERN}"
-        
-        # List packages matching the pattern and delete them
-        # Packages are user-scoped but linked to repository, use /users/{owner}/packages
-        PACKAGES=$(gh api "/users/${OWNER}/packages?package_type=container" --jq ".[] | select(.name | contains(\"${PATTERN}\")) | .name" 2>&1) || {
-          echo "::warning::Failed to list packages: ${PACKAGES}"
-          exit 1
-        }
-        
-        if [ -z "$PACKAGES" ]; then
-          echo "No packages found matching pattern: ${PATTERN}"
-          exit 0
-        fi
-        
-        while read -r package_name; do
-          # URL-encode the package name (slashes become %2F)
-          encoded_name=$(printf '%s' "$package_name" | jq -sRr @uri)
-          echo "Deleting package: ${package_name}"
-          if ! gh api --method DELETE "/users/${OWNER}/packages/container/${encoded_name}" 2>&1; then
-            echo "::warning::Failed to delete package: ${package_name}"
-            FAILED=1
-          fi
-        done <<< "$PACKAGES"
-        
-        if [ "$FAILED" -eq 1 ]; then
-          echo "::warning::Some packages failed to delete"
-          exit 1
-        fi
-        
-        echo "Cleanup complete"
+        .github/scripts/cleanup-e2e-images.sh \
+          "${{ github.event.pull_request.number || github.run_id }}" \
+          "${{ github.repository_owner }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem
The CI workflow should clean up test images pushed to ghcr.io after e2e tests complete, but:
1. Cleanup step was skipped on push events (only ran for PRs)
2. Cleanup silently failed on PRs due to wrong API endpoint

## Root Cause
- **Skipped on push**: The condition `github.event_name == 'pull_request'` prevented cleanup on push events, leaving images like `e2e-21967261848`
- **Silent failure on PRs**: Used `/user/packages` API endpoint, but `GITHUB_TOKEN` authenticates as `github-actions[bot]`, not as user `cardil`, causing HTTP 400 errors

## Changes
- ✅ Removed `github.event_name == 'pull_request'` condition so cleanup runs on **all events** (push and PR)
- ✅ Changed from `/user/packages` to `/users/${OWNER}/packages` API endpoint
- ✅ Added `OWNER` variable using `github.repository_owner` context
- ✅ Updated comments to reflect that cleanup works for all test runs, not just PRs

## Verification
- Manually cleaned up leftover images: `e2e-6` (PR #6) and `e2e-21967261848` (push run)
- Verified no e2e images remain on ghcr.io
- The fix will be tested when this PR runs e2e tests

Assisted-by: 🤖 Claude Opus/Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI cleanup of e2e images in ghcr.io so it runs on all events and reliably deletes test images with GITHUB_TOKEN. Moves cleanup to a reusable script that deletes known packages directly and fails loudly on real errors.

- **Bug Fixes**
  - Run on all events.
  - Delete known e2e packages directly via /users/{owner}/packages; compatible with GITHUB_TOKEN.
  - Use owner from github.repository_owner and repo from the event; target e2e-${RUN_ID}.
  - Treat 404 as not created; fail only on real errors.
  - Prevent premature exit by using DELETED=$((DELETED + 1)) instead of ((DELETED++)) under set -e.

- **Refactors**
  - Move logic to .github/scripts/cleanup-e2e-images.sh and call from workflow.
  - Enable strict mode, remove continue-on-error, aggregate failures and exit non-zero.

<sup>Written for commit b359d29ed85258e95db09b2c9f95f8933c5cc409. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved e2e image cleanup to a centralized external script for consistent handling.
  * Cleanup now runs for all workflow outcomes to ensure test artifacts are removed reliably.
  * Cleanup failures are no longer ignored; errors are surfaced to improve observability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->