### PR TITLE
Add release automation via goyek tasks

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,4 @@
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "pkg/client"
+  - "build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,11 +28,6 @@ jobs:
         go-version-file: go.mod
         cache: true
 
-    - name: Set up QEMU for multi-arch builds
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: linux/arm64
-
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 The Knative Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Set up QEMU for multi-arch builds
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/arm64
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run release
+      run: ./goyek release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/pipelines/default.go
+++ b/build/pipelines/default.go
@@ -14,6 +14,7 @@ func Default() *goyek.Flow {
 	tasks.Deploy(f)
 	tasks.Update(f)
 	tasks.Test(f)
+	tasks.Release(f)
 	f.SetDefault(f.Define(tasks.Build()))
 	return f
 }

--- a/build/tasks/release.go
+++ b/build/tasks/release.go
@@ -145,14 +145,8 @@ func ReleasePerform() goyek.Task {
 			runnerImage := path.Join(repo, "runner")
 			versionedRunner := runnerImage + ":v" + version
 
-			// Push runner image from local buildah storage
-			pushRunnerImageMultiArch(a, versionedRunner, runnerImage+":latest")
-
-			// Push controller image from OCI layout via skopeo
-			controllerImage := path.Join(repo, "controller")
-			pushControllerImage(a, controllerImage, version)
-
-			// Read artifact list
+			// Validate artifact list before any remote mutations.
+			// This fails fast if release:build was not run first.
 			artifactBytes, err := os.ReadFile(artifactListFile)
 			if err != nil {
 				a.Fatalf("Failed to read artifact list (run release:build first): %v", err)
@@ -163,6 +157,13 @@ func ReleasePerform() goyek.Task {
 					artifacts = append(artifacts, line)
 				}
 			}
+
+			// Push runner image from local buildah storage
+			pushRunnerImageMultiArch(a, versionedRunner, runnerImage+":latest")
+
+			// Push controller image from OCI layout via skopeo
+			controllerImage := path.Join(repo, "controller")
+			pushControllerImage(a, controllerImage, version)
 
 			// Derive release branch from version (e.g. 0.1.2 -> release-0.1)
 			tag := "v" + version
@@ -194,19 +195,29 @@ func ReleasePerform() goyek.Task {
 func detectReleaseVersion(a *goyek.A) string {
 	a.Helper()
 
+	normalize := func(v string) string {
+		v = strings.TrimPrefix(v, "v")
+		parts := strings.SplitN(v, ".", 3)
+		if len(parts) < 2 {
+			a.Fatalf("Invalid release version %q: expected vX.Y or vX.Y.Z", v)
+		}
+		return v
+	}
+
 	// 1. RELEASE_VERSION env var (e.g. set by hack/release.sh from Prow TAG)
 	if v := os.Getenv("RELEASE_VERSION"); v != "" {
-		return strings.TrimPrefix(v, "v")
+		return normalize(v)
 	}
 
-	// 2. Git tag on HEAD matching v*
-	if v := gitTagOnHead(); v != "" {
-		return strings.TrimPrefix(v, "v")
-	}
-
-	// 3. GITHUB_REF_NAME (GH Actions tag push, e.g. "v0.1.0")
+	// 2. GITHUB_REF_NAME (GH Actions tag push, e.g. "v0.1.0") — prefer the
+	//    exact tag that triggered the workflow over a local git lookup.
 	if v := os.Getenv("GITHUB_REF_NAME"); strings.HasPrefix(v, "v") {
-		return strings.TrimPrefix(v, "v")
+		return normalize(v)
+	}
+
+	// 3. Git tag on HEAD matching v* (local / non-GH-Actions invocations)
+	if v := gitTagOnHead(); v != "" {
+		return normalize(v)
 	}
 
 	a.Fatal("Cannot determine release version: set RELEASE_VERSION env var, " +

--- a/build/tasks/release.go
+++ b/build/tasks/release.go
@@ -26,7 +26,6 @@ import (
 	executil "github.com/cardil/knative-serving-wasm/build/util/exec"
 	"github.com/cardil/knative-serving-wasm/build/util/tools"
 	"github.com/goyek/goyek/v2"
-	gocmd "github.com/goyek/x/cmd"
 	"go.yaml.in/yaml/v2"
 )
 
@@ -329,20 +328,34 @@ func buildControllerLocal(a *goyek.A, repo, runnerImage, version string) string 
 	ko := tools.Ghet(a, "ko")
 	tmpYAML := path.Join(releaseOutputDir, "serving-wasm-raw.yaml")
 
-	// Run ko resolve --push=false --oci-layout-path, redirect output to file
-	executil.ExecOrDie(a, spaceJoin(
-		ko, "resolve",
+	// Run ko resolve --push=false --oci-layout-path, capture stdout into file.
+	// We use os/exec directly so we can redirect stdout to the file while still
+	// streaming stderr (ko logs) to the task output.
+	//nolint:gosec
+	koCmd := exec.Command(ko, "resolve", //nolint:govet
 		"-B",
 		"--push=false",
 		"--oci-layout-path", ociControllerDir,
 		"--platform", "linux/amd64,linux/arm64",
 		"--tags", "v"+version+",latest",
 		"-f", "config/",
-		">", tmpYAML,
-	),
-		gocmd.Env("KO_DOCKER_REPO", repo),
-		gocmd.Env("KO_CONFIG_PATH", releaseOutputDir),
 	)
+	koCmd.Env = append(os.Environ(),
+		"KO_DOCKER_REPO="+repo,
+		"KO_CONFIG_PATH="+releaseOutputDir,
+	)
+	koCmd.Stderr = os.Stderr // stream ko logs to terminal
+
+	outFile, err := os.Create(tmpYAML)
+	if err != nil {
+		a.Fatalf("Failed to create raw YAML file: %v", err)
+	}
+	koCmd.Stdout = outFile
+	if err := koCmd.Run(); err != nil {
+		_ = outFile.Close()
+		a.Fatalf("ko resolve failed: %v", err)
+	}
+	_ = outFile.Close()
 
 	content, err := os.ReadFile(tmpYAML)
 	if err != nil {

--- a/build/tasks/release.go
+++ b/build/tasks/release.go
@@ -1,0 +1,416 @@
+// Copyright 2026 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	executil "github.com/cardil/knative-serving-wasm/build/util/exec"
+	"github.com/cardil/knative-serving-wasm/build/util/tools"
+	"github.com/goyek/goyek/v2"
+	gocmd "github.com/goyek/x/cmd"
+	"go.yaml.in/yaml/v2"
+)
+
+const (
+	releaseOutputDir  = "build/output/release"
+	ociControllerDir  = "build/output/release/oci-controller"
+	releaseYAML       = "build/output/release/serving-wasm.yaml"
+	checksumsFile     = "build/output/release/checksums.txt"
+	artifactListFile  = "build/output/release/artifacts-to-publish.list"
+	versionFile       = "build/output/release/version.txt"
+	releaseLabelDevel = "wasm.serving.knative.dev/release: devel"
+)
+
+// Release registers the release, release-build, release-perform, and release-clean tasks.
+func Release(f *goyek.Flow) {
+	clean := f.Define(ReleaseClean())
+	build := f.Define(ReleaseBuild())
+	perform := f.Define(ReleasePerform())
+	f.Define(goyek.Task{
+		Name:  "release",
+		Usage: "Builds and publishes a tagged release",
+		Deps:  goyek.Deps{build, perform},
+	})
+	_ = clean
+}
+
+// ReleaseClean removes all release build artifacts.
+func ReleaseClean() goyek.Task {
+	return goyek.Task{
+		Name:  "release-clean",
+		Usage: "Removes release build artifacts from build/output/release/",
+		Action: func(a *goyek.A) {
+			if err := os.RemoveAll(releaseOutputDir); err != nil {
+				a.Errorf("Failed to remove release output dir: %v", err)
+			} else {
+				a.Log("Removed: ", releaseOutputDir)
+			}
+		},
+	}
+}
+
+// ReleaseBuild builds all release artifacts locally — no registry push.
+// It saves the resolved version to build/output/release/version.txt.
+func ReleaseBuild() goyek.Task {
+	return goyek.Task{
+		Name:  "release-build",
+		Usage: "Builds release artifacts locally (no registry push), saves version to build/output/release/version.txt",
+		Action: func(a *goyek.A) {
+			setupKoEnv(a)
+
+			version := detectReleaseVersion(a)
+			a.Log("Release version: ", version)
+
+			repo := os.Getenv(koDockerRepo)
+
+			if err := os.MkdirAll(releaseOutputDir, 0755); err != nil {
+				a.Fatalf("Failed to create release output dir: %v", err)
+			}
+			if err := os.MkdirAll(ociControllerDir, 0755); err != nil {
+				a.Fatalf("Failed to create OCI controller dir: %v", err)
+			}
+
+			// Save version for release:perform to consume
+			if err := os.WriteFile(versionFile, []byte(version+"\n"), 0644); err != nil {
+				a.Fatalf("Failed to write version file: %v", err)
+			}
+			a.Log("Version saved to: ", versionFile)
+
+			// Branch/tag management — skip if TAG env already set (Prow manages it)
+			if os.Getenv("TAG") == "" {
+				manageBranchAndTag(a, version)
+			}
+
+			runnerImage := path.Join(repo, "runner") + ":v" + version
+
+			// Build multi-arch runner image locally (no push)
+			buildRunnerImageMultiArch(a, runnerImage)
+
+			// Build controller locally via ko resolve --push=false --oci-layout-path
+			rawYAML := buildControllerLocal(a, repo, runnerImage, version)
+
+			// Replace OCI local path with real registry ref + update release label
+			finalYAML := replaceImageRefs(rawYAML, ociControllerDir, repo, version)
+
+			if err := os.WriteFile(releaseYAML, []byte(finalYAML), 0644); err != nil {
+				a.Fatalf("Failed to write release YAML: %v", err)
+			}
+			a.Log("Release YAML written to: ", releaseYAML)
+
+			// Generate checksums
+			generateChecksums(a)
+
+			// Write artifacts list
+			artifacts := releaseYAML + "\n" + checksumsFile + "\n"
+			if err := os.WriteFile(artifactListFile, []byte(artifacts), 0644); err != nil {
+				a.Fatalf("Failed to write artifact list: %v", err)
+			}
+			a.Log("Artifact list written to: ", artifactListFile)
+		},
+	}
+}
+
+// ReleasePerform pushes images and creates the GitHub release.
+// It reads the version from build/output/release/version.txt (written by release-build).
+// On success, it removes the release output directory.
+func ReleasePerform() goyek.Task {
+	return goyek.Task{
+		Name:  "release-perform",
+		Usage: "Pushes images and publishes GitHub release (reads version from build/output/release/version.txt)",
+		Action: func(a *goyek.A) {
+			setupKoEnv(a)
+
+			// Read version written by release:build
+			versionBytes, err := os.ReadFile(versionFile)
+			if err != nil {
+				a.Fatalf("Failed to read version file %q (run release:build first): %v", versionFile, err)
+			}
+			version := strings.TrimSpace(string(versionBytes))
+			a.Log("Release version (from file): ", version)
+
+			repo := os.Getenv(koDockerRepo)
+			runnerImage := path.Join(repo, "runner")
+			versionedRunner := runnerImage + ":v" + version
+
+			// Push runner image from local buildah storage
+			pushRunnerImageMultiArch(a, versionedRunner, runnerImage+":latest")
+
+			// Push controller image from OCI layout via skopeo
+			controllerImage := path.Join(repo, "controller")
+			pushControllerImage(a, controllerImage, version)
+
+			// Read artifact list
+			artifactBytes, err := os.ReadFile(artifactListFile)
+			if err != nil {
+				a.Fatalf("Failed to read artifact list (run release:build first): %v", err)
+			}
+			var artifacts []string
+			for _, line := range strings.Split(strings.TrimSpace(string(artifactBytes)), "\n") {
+				if line = strings.TrimSpace(line); line != "" {
+					artifacts = append(artifacts, line)
+				}
+			}
+
+			// Derive release branch from version (e.g. 0.1.2 -> release-0.1)
+			tag := "v" + version
+			parts := strings.SplitN(version, ".", 3)
+			releaseBranch := "release-" + parts[0] + "." + parts[1]
+
+			// Create GitHub release
+			ghArgs := []string{
+				"gh", "release", "create", tag,
+				"--title", tag,
+				"--generate-notes",
+				"--target", releaseBranch,
+			}
+			ghArgs = append(ghArgs, artifacts...)
+			executil.ExecOrDie(a, strings.Join(ghArgs, " "))
+
+			// Clean up release output on success
+			a.Log("Cleaning up release artifacts...")
+			if err := os.RemoveAll(releaseOutputDir); err != nil {
+				// Non-fatal — release was published successfully
+				a.Logf("Warning: failed to clean release output dir: %v", err)
+			}
+		},
+	}
+}
+
+// detectReleaseVersion resolves the release version (without "v" prefix) from
+// environment variables or git tags. Used only by release:build.
+func detectReleaseVersion(a *goyek.A) string {
+	a.Helper()
+
+	// 1. RELEASE_VERSION env var (e.g. set by hack/release.sh from Prow TAG)
+	if v := os.Getenv("RELEASE_VERSION"); v != "" {
+		return strings.TrimPrefix(v, "v")
+	}
+
+	// 2. Git tag on HEAD matching v*
+	if v := gitTagOnHead(); v != "" {
+		return strings.TrimPrefix(v, "v")
+	}
+
+	// 3. GITHUB_REF_NAME (GH Actions tag push, e.g. "v0.1.0")
+	if v := os.Getenv("GITHUB_REF_NAME"); strings.HasPrefix(v, "v") {
+		return strings.TrimPrefix(v, "v")
+	}
+
+	a.Fatal("Cannot determine release version: set RELEASE_VERSION env var, " +
+		"ensure HEAD has a v* git tag, or run from a GH Actions tag push (GITHUB_REF_NAME=v...)")
+	return ""
+}
+
+// gitTagOnHead returns the first v* tag pointing at HEAD, or empty string.
+func gitTagOnHead() string {
+	out, err := exec.Command("git", "tag", "--points-at", "HEAD", "--list", "v*").Output()
+	if err != nil {
+		return ""
+	}
+	tags := strings.Fields(strings.TrimSpace(string(out)))
+	if len(tags) == 0 {
+		return ""
+	}
+	return tags[0]
+}
+
+// manageBranchAndTag creates the release branch and tag if they don't exist.
+func manageBranchAndTag(a *goyek.A, version string) {
+	a.Helper()
+
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		a.Fatalf("Invalid version format (expected X.Y.Z): %s", version)
+	}
+	releaseBranch := "release-" + parts[0] + "." + parts[1]
+	tag := "v" + version
+
+	// Check if release branch exists on remote
+	checkBranch := exec.Command("git", "ls-remote", "--exit-code", "--heads", "origin", releaseBranch)
+	if err := checkBranch.Run(); err != nil {
+		a.Log("Creating release branch: ", releaseBranch)
+		executil.ExecOrDie(a, spaceJoin("git", "checkout", "-b", releaseBranch))
+		executil.ExecOrDie(a, spaceJoin("git", "push", "origin", releaseBranch))
+	} else {
+		a.Log("Release branch already exists: ", releaseBranch)
+	}
+
+	// Check if tag exists on remote
+	checkTag := exec.Command("git", "ls-remote", "--exit-code", "--tags", "origin", tag)
+	if err := checkTag.Run(); err != nil {
+		a.Log("Creating tag: ", tag)
+		executil.ExecOrDie(a, spaceJoin("git", "tag", tag))
+		executil.ExecOrDie(a, spaceJoin("git", "push", "origin", tag))
+	} else {
+		a.Log("Tag already exists: ", tag)
+	}
+}
+
+// buildRunnerImageMultiArch builds the runner image for linux/amd64,linux/arm64
+// into local buildah manifest storage (no push).
+func buildRunnerImageMultiArch(a *goyek.A, manifestName string) {
+	a.Helper()
+	a.Log("Building multi-arch runner image locally: ", manifestName)
+	executil.ExecOrDie(a, spaceJoin(
+		"buildah", "build",
+		"--platform", "linux/amd64,linux/arm64",
+		"--manifest", manifestName,
+		"--layers",
+		"runner/",
+	))
+}
+
+// pushRunnerImageMultiArch pushes the locally-stored runner manifest to the registry.
+func pushRunnerImageMultiArch(a *goyek.A, versionedTag, latestTag string) {
+	a.Helper()
+	a.Log("Pushing runner image: ", versionedTag)
+	executil.ExecOrDie(a, spaceJoin(
+		"buildah", "manifest", "push", "--all",
+		versionedTag, "docker://"+versionedTag,
+	))
+	a.Log("Pushing runner image: ", latestTag)
+	executil.ExecOrDie(a, spaceJoin(
+		"buildah", "manifest", "push", "--all",
+		versionedTag, "docker://"+latestTag,
+	))
+}
+
+// buildControllerLocal runs ko resolve --push=false --oci-layout-path and returns
+// the raw YAML content (with OCI local path refs).
+func buildControllerLocal(a *goyek.A, repo, runnerImage, version string) string {
+	a.Helper()
+
+	// Write .ko.yaml with ldflags pointing to the tagged runner image
+	type koBuild struct {
+		ID      string   `yaml:"id"`
+		Dir     string   `yaml:"dir"`
+		Ldflags []string `yaml:"ldflags"`
+	}
+	type koConfig struct {
+		Builds []koBuild `yaml:"builds"`
+	}
+	config := koConfig{
+		Builds: []koBuild{{
+			ID:  "controller",
+			Dir: "./cmd/controller",
+			Ldflags: []string{
+				fmt.Sprintf("-X github.com/cardil/knative-serving-wasm/pkg/reconciler/wasmmodule.DefaultRunnerImage=%s", runnerImage),
+			},
+		}},
+	}
+	configYAML, err := yaml.Marshal(config)
+	if err != nil {
+		a.Fatalf("Failed to marshal ko config: %v", err)
+	}
+	koConfigPath := path.Join(releaseOutputDir, ".ko.yaml")
+	if err := os.WriteFile(koConfigPath, configYAML, 0644); err != nil {
+		a.Fatalf("Failed to write ko config: %v", err)
+	}
+
+	ko := tools.Ghet(a, "ko")
+	tmpYAML := path.Join(releaseOutputDir, "serving-wasm-raw.yaml")
+
+	// Run ko resolve --push=false --oci-layout-path, redirect output to file
+	executil.ExecOrDie(a, spaceJoin(
+		ko, "resolve",
+		"-B",
+		"--push=false",
+		"--oci-layout-path", ociControllerDir,
+		"--platform", "linux/amd64,linux/arm64",
+		"--tags", "v"+version+",latest",
+		"-f", "config/",
+		">", tmpYAML,
+	),
+		gocmd.Env("KO_DOCKER_REPO", repo),
+		gocmd.Env("KO_CONFIG_PATH", releaseOutputDir),
+	)
+
+	content, err := os.ReadFile(tmpYAML)
+	if err != nil {
+		a.Fatalf("Failed to read raw YAML: %v", err)
+	}
+	return string(content)
+}
+
+// replaceImageRefs replaces the OCI local path prefix in the YAML with the real
+// registry controller image ref (preserving the sha256 digest), and also
+// replaces the devel release label with the versioned label.
+func replaceImageRefs(rawYAML, ociLayoutPath, repo, version string) string {
+	controllerRef := path.Join(repo, "controller")
+
+	// Replace OCI layout path ref with real registry ref, preserving digest
+	// e.g. "build/output/release/oci-controller@sha256:abc" -> "ghcr.io/.../controller@sha256:abc"
+	result := strings.ReplaceAll(rawYAML, ociLayoutPath+"@sha256:", controllerRef+"@sha256:")
+
+	// Replace devel release label with versioned label
+	versionLabel := "wasm.serving.knative.dev/release: \"v" + version + "\""
+	result = strings.ReplaceAll(result, releaseLabelDevel, versionLabel)
+
+	return result
+}
+
+// generateChecksums computes sha256 of the release YAML and writes checksums.txt.
+func generateChecksums(a *goyek.A) {
+	a.Helper()
+
+	f, err := os.Open(releaseYAML)
+	if err != nil {
+		a.Fatalf("Failed to open release YAML for checksumming: %v", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		a.Fatalf("Failed to compute sha256: %v", err)
+	}
+
+	// Format: "<hex>  <filename>" (sha256sum compatible)
+	yamlBase := path.Base(releaseYAML)
+	checksumLine := fmt.Sprintf("%x  %s\n", h.Sum(nil), yamlBase)
+
+	if err := os.WriteFile(checksumsFile, []byte(checksumLine), 0644); err != nil {
+		a.Fatalf("Failed to write checksums file: %v", err)
+	}
+	a.Log("Checksums written to: ", checksumsFile)
+}
+
+// pushControllerImage pushes the controller OCI layout to the registry via skopeo.
+func pushControllerImage(a *goyek.A, controllerRef, version string) {
+	a.Helper()
+
+	versionedRef := controllerRef + ":v" + version
+	latestRef := controllerRef + ":latest"
+
+	a.Log("Pushing controller image: ", versionedRef)
+	executil.ExecOrDie(a, spaceJoin(
+		"skopeo", "copy",
+		"oci:"+ociControllerDir,
+		"docker://"+versionedRef,
+	))
+
+	a.Log("Pushing controller image: ", latestRef)
+	executil.ExecOrDie(a, spaceJoin(
+		"skopeo", "copy",
+		"oci:"+ociControllerDir,
+		"docker://"+latestRef,
+	))
+}

--- a/build/tasks/release.go
+++ b/build/tasks/release.go
@@ -94,11 +94,6 @@ func ReleaseBuild() goyek.Task {
 			}
 			a.Log("Version saved to: ", versionFile)
 
-			// Branch/tag management — skip if TAG env already set (Prow manages it)
-			if os.Getenv("TAG") == "" {
-				manageBranchAndTag(a, version)
-			}
-
 			runnerImage := path.Join(repo, "runner") + ":v" + version
 
 			// Build multi-arch runner image locally (no push)
@@ -342,7 +337,7 @@ func buildControllerLocal(a *goyek.A, repo, runnerImage, version string) string 
 	)
 	koCmd.Env = append(os.Environ(),
 		"KO_DOCKER_REPO="+repo,
-		"KO_CONFIG_PATH="+releaseOutputDir,
+		"KO_CONFIG_PATH="+koConfigPath,
 	)
 	koCmd.Stderr = os.Stderr // stream ko logs to terminal
 
@@ -415,14 +410,14 @@ func pushControllerImage(a *goyek.A, controllerRef, version string) {
 
 	a.Log("Pushing controller image: ", versionedRef)
 	executil.ExecOrDie(a, spaceJoin(
-		"skopeo", "copy",
+		"skopeo", "copy", "--all",
 		"oci:"+ociControllerDir,
 		"docker://"+versionedRef,
 	))
 
 	a.Log("Pushing controller image: ", latestRef)
 	executil.ExecOrDie(a, spaceJoin(
-		"skopeo", "copy",
+		"skopeo", "copy", "--all",
 		"oci:"+ociControllerDir,
 		"docker://"+latestRef,
 	))

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,30 +18,17 @@
 # shellcheck disable=SC1090
 source "$(go run knative.dev/hack/cmd/script release.sh)"
 
-declare -A COMPONENTS
-COMPONENTS=(
-  ["sample.yaml"]="config"
-)
-readonly COMPONENTS
-
 function build_release() {
-   # Update release labels if this is a tagged release
-  if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to wasm.serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|wasm.serving.knative.dev/release: devel|wasm.serving.knative.dev/release: \"${TAG}\"|")
-  else
-    echo "Untagged release, will NOT update release labels"
-    LABEL_YAML_CMD=(cat)
-  fi
+  # Delegate to goyek release:build which handles:
+  #   - runner multi-arch image (buildah, local only)
+  #   - controller image (ko resolve --push=false, OCI layout)
+  #   - YAML generation and checksums
+  # TAG and KO_DOCKER_REPO are already set by the Knative release framework.
+  # RELEASE_VERSION is derived from TAG (strip the "v" prefix).
+  RELEASE_VERSION="${TAG#v}" ./goyek --no-deps release-build
 
-  local all_yamls=()
-  for yaml in "${!COMPONENTS[@]}"; do
-    local config="${COMPONENTS[${yaml}]}"
-    echo "Building Knative Sample Controller - ${config}"
-    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
-    all_yamls+=(${yaml})
-  done
-  ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
+  # Read the artifact list produced by release:build
+  ARTIFACTS_TO_PUBLISH="$(tr '\n' ' ' < build/output/release/artifacts-to-publish.list)"
 }
 
 main "$@"

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -19,24 +19,15 @@ ARG TARGETARCH
 RUN mkdir /code
 WORKDIR /code
 
-# Pre-fetch dependencies for layer caching: copy manifests only,
-# fetch all crates, build a placeholder binary to cache compiled deps,
-# then copy real source.
+# Pre-fetch dependency crates into ~/.cargo/registry in a stable layer
+# (only invalidated when Cargo.toml/Cargo.lock change). This avoids
+# re-downloading crates on every source change without risking stale
+# placeholder build artifacts interfering with the real build.
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo fetch --locked && rm -rf src
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
-    case "${TARGETARCH}" in \
-      amd64) \
-        cargo build --release 2>/dev/null; true \
-        ;; \
-      arm64) \
-        PKG_CONFIG_ALLOW_CROSS=1 \
-        PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-        cargo build --release --target aarch64-unknown-linux-gnu 2>/dev/null; true \
-        ;; \
-    esac && \
-    rm -rf src target/release/runner target/aarch64-unknown-linux-gnu/release/runner
+RUN mkdir src && \
+  echo 'fn main() {}' > src/main.rs && \
+  cargo fetch --locked \
+  && rm -rf src
 
 COPY . .
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
         cargo build --release --target aarch64-unknown-linux-gnu 2>/dev/null; true \
         ;; \
     esac && \
-    rm -rf src
+    rm -rf src target
 
 COPY . .
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,10 +1,15 @@
-FROM docker.io/library/rust:1 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:1 AS builder
 
-# Install cross-compilation toolchains for supported non-native architectures
+# Enable arm64 packages for cross-compilation sysroot
+RUN dpkg --add-architecture arm64
+
+# Install cross-compilation toolchains and arm64 OpenSSL sysroot
 RUN apt-get update && apt-get install -y --no-install-recommends \
       gcc-aarch64-linux-gnu \
-      libc6-dev-arm64-cross && \
-    rm -rf /var/lib/apt/lists/*
+      libc6-dev-arm64-cross \
+      libssl-dev:arm64 \
+      pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add Rust targets for cross-compilation
 RUN rustup target add aarch64-unknown-linux-gnu
@@ -13,6 +18,26 @@ ARG TARGETARCH
 
 RUN mkdir /code
 WORKDIR /code
+
+# Pre-fetch dependencies for layer caching: copy manifests only,
+# fetch all crates, build a dummy binary to cache compiled deps,
+# then copy real source.
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo fetch --locked && rm -rf src
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
+    case "${TARGETARCH}" in \
+      amd64) \
+        cargo build --release 2>/dev/null; true \
+        ;; \
+      arm64) \
+        PKG_CONFIG_ALLOW_CROSS=1 \
+        PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+        cargo build --release --target aarch64-unknown-linux-gnu 2>/dev/null; true \
+        ;; \
+    esac && \
+    rm -rf src
+
 COPY . .
 
 # Build for the target architecture:
@@ -23,6 +48,8 @@ RUN case "${TARGETARCH}" in \
         cargo build --release \
         ;; \
       arm64) \
+        PKG_CONFIG_ALLOW_CROSS=1 \
+        PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
         cargo build --release --target aarch64-unknown-linux-gnu && \
         cp target/aarch64-unknown-linux-gnu/release/runner target/release/runner \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,10 +1,34 @@
-FROM docker.io/library/rust:1 as builder
+FROM docker.io/library/rust:1 AS builder
+
+# Install cross-compilation toolchains for supported non-native architectures
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      gcc-aarch64-linux-gnu \
+      libc6-dev-arm64-cross && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add Rust targets for cross-compilation
+RUN rustup target add aarch64-unknown-linux-gnu
+
+ARG TARGETARCH
 
 RUN mkdir /code
 WORKDIR /code
 COPY . .
 
-RUN cargo build --release
+# Build for the target architecture:
+#   amd64 -> native build
+#   arm64 -> cross-compile with aarch64-linux-gnu-gcc (no QEMU needed)
+RUN case "${TARGETARCH}" in \
+      amd64) \
+        cargo build --release \
+        ;; \
+      arm64) \
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+        cargo build --release --target aarch64-unknown-linux-gnu && \
+        cp target/aarch64-unknown-linux-gnu/release/runner target/release/runner \
+        ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac
 
 FROM gcr.io/distroless/cc-debian12
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /code
 WORKDIR /code
 
 # Pre-fetch dependencies for layer caching: copy manifests only,
-# fetch all crates, build a dummy binary to cache compiled deps,
+# fetch all crates, build a placeholder binary to cache compiled deps,
 # then copy real source.
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo fetch --locked && rm -rf src

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,5 +1,11 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/rust:1 AS builder
 
+ARG BUILDPLATFORM
+# The amd64 target is built natively; arm64 is cross-compiled. Both require
+# an amd64 build host. Fail early on non-amd64 builders.
+RUN [ "${BUILDPLATFORM}" = "linux/amd64" ] || \
+    { echo "ERROR: builder must be linux/amd64, got ${BUILDPLATFORM}"; exit 1; }
+
 # Enable arm64 packages for cross-compilation sysroot
 RUN dpkg --add-architecture arm64
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
         cargo build --release --target aarch64-unknown-linux-gnu 2>/dev/null; true \
         ;; \
     esac && \
-    rm -rf src target
+    rm -rf src target/release/runner target/aarch64-unknown-linux-gnu/release/runner
 
 COPY . .
 


### PR DESCRIPTION
## Summary

Automates the manual release process from v0.1.0 into persistent `./goyek` tasks.

## Tasks

- `release-build`: builds all artifacts **locally, no registry push**
  - Multi-arch runner image via `buildah build --platform linux/amd64,linux/arm64 --manifest`
  - Controller image via `ko resolve -B --push=false --oci-layout-path`
  - Replaces OCI local path refs with real registry refs (preserving sha256 digests)
  - Replaces `wasm.serving.knative.dev/release: devel` label with version
  - Generates `serving-wasm.yaml`, `checksums.txt`, `artifacts-to-publish.list`
  - Saves resolved version to `build/output/release/version.txt`

- `release-perform`: pushes images and creates GH release
  - Reads version from `version.txt` (written by `release-build`)
  - Pushes runner via `buildah manifest push --all`
  - Pushes controller via `skopeo copy oci:<dir> docker://<ref>`
  - Creates GitHub release with artifacts
  - Cleans up `build/output/release/` on success

- `release-clean`: removes `build/output/release/`

- `release`: orchestrates `release-build` + `release-perform`

## Integration

- **`hack/release.sh`**: `build_release()` now delegates to `./goyek --no-deps release-build` for Knative Prow compatibility
- **`.github/workflows/release.yaml`**: new GH Actions workflow triggered on `v*` tag push; includes QEMU setup for arm64 cross-compilation

## Verified

- `ko resolve --push=false --oci-layout-path` + `skopeo copy` preserves exact sha256 digest (tested against ttl.sh)
- `buildah build --manifest` stores locally without pushing (verified with `skopeo inspect`)
- `make help` works (task names use `-` not `:` to be Make-compatible)

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates releases with goyek tasks and a tag-triggered GitHub Actions workflow. Builds and pushes multi-arch images, preserves digests, publishes artifacts, and creates a GitHub release; arm64 runner cross-compiles natively with cached deps (no QEMU), with validation, reliable ko resolve, and build-host guards.

- **New Features**
  - Added goyek tasks: release-build, release-perform, release-clean, and release; included in the default pipeline.
  - release-build: local multi-arch runner (buildah) and controller (ko to OCI layout), ref/label rewrite, serving-wasm.yaml, checksums, artifact list, version.txt.
  - release-perform: pushes images (buildah/skopeo --all), creates a GitHub release (gh), then cleans build/output/release/; workflow runs on v* tags.

- **Refactors**
  - Exclude build/ from coverage in .codecov.yaml.

<sup>Written for commit 093ee8440071873a1bfff2594b1c0a8ac230dca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI release workflow triggered by version tags.
  * Integrated a release step into the default pipeline and simplified the release script to delegate artifact preparation.
  * Updated code coverage config to ignore build artifacts.

* **New Features**
  * Release tooling now prepares and publishes multi-architecture images, controller manifests, artifacts and checksums.
  * Runner build supports cross-platform (amd64/arm64) multi-arch compilation and packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->