### PR TITLE
Propagate terminal ksvc failure to WasmModule status

### DIFF
--- a/pkg/apis/wasm/v1alpha1/wasm_module_lifecycle.go
+++ b/pkg/apis/wasm/v1alpha1/wasm_module_lifecycle.go
@@ -45,6 +45,17 @@ func (ass *WasmModuleStatus) MarkServiceUnavailable(name string) {
 		"Service %q wasn't found.", name)
 }
 
+// MarkServiceFailed marks the WasmModule as permanently failed, propagating
+// the terminal failure reason and message from the underlying Knative Service.
+// Use this when the ksvc has a terminal failure (e.g. RevisionFailed,
+// ContainerMissing) so clients can distinguish transient from terminal errors.
+func (ass *WasmModuleStatus) MarkServiceFailed(reason, message string) {
+	condSet.Manage(ass).MarkFalse(
+		WasmModuleConditionReady,
+		reason,
+		"%s", message)
+}
+
 func (ass *WasmModuleStatus) MarkServiceAvailable() {
 	condSet.Manage(ass).MarkTrue(WasmModuleConditionReady)
 }

--- a/pkg/apis/wasm/v1alpha1/wasm_module_lifecycle_test.go
+++ b/pkg/apis/wasm/v1alpha1/wasm_module_lifecycle_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
+	"knative.dev/pkg/apis"
+)
+
+func TestMarkServiceFailed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		reason      string
+		message     string
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "RevisionFailed propagated",
+			reason:      "RevisionFailed",
+			message:     "Revision 'foo-00001' failed with message: OCI pull failed.",
+			wantReason:  "RevisionFailed",
+			wantMessage: "Revision 'foo-00001' failed with message: OCI pull failed.",
+		},
+		{
+			name:        "ContainerMissing propagated",
+			reason:      "ContainerMissing",
+			message:     "Image 'ghcr.io/bad/image' not found.",
+			wantReason:  "ContainerMissing",
+			wantMessage: "Image 'ghcr.io/bad/image' not found.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			status := &v1alpha1.WasmModuleStatus{}
+			status.InitializeConditions()
+			status.MarkServiceFailed(tt.reason, tt.message)
+
+			cond := status.GetCondition(apis.ConditionReady)
+			if cond == nil {
+				t.Fatal("expected Ready condition, got nil")
+			}
+
+			if !cond.IsFalse() {
+				t.Errorf("expected condition to be False, got %v", cond.Status)
+			}
+
+			if cond.Reason != tt.wantReason {
+				t.Errorf("reason: got %q, want %q", cond.Reason, tt.wantReason)
+			}
+
+			if cond.Message != tt.wantMessage {
+				t.Errorf("message: got %q, want %q", cond.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestMarkServiceFailedDiffersFromUnavailable(t *testing.T) {
+	t.Parallel()
+
+	unavailable := &v1alpha1.WasmModuleStatus{}
+	unavailable.InitializeConditions()
+	unavailable.MarkServiceUnavailable("my-svc")
+
+	failed := &v1alpha1.WasmModuleStatus{}
+	failed.InitializeConditions()
+	failed.MarkServiceFailed("RevisionFailed", "crashed")
+
+	unavailableCond := unavailable.GetCondition(apis.ConditionReady)
+	failedCond := failed.GetCondition(apis.ConditionReady)
+
+	if unavailableCond.Reason != "ServiceUnavailable" {
+		t.Errorf("MarkServiceUnavailable reason: got %q, want %q", unavailableCond.Reason, "ServiceUnavailable")
+	}
+
+	if failedCond.Reason != "RevisionFailed" {
+		t.Errorf("MarkServiceFailed reason: got %q, want %q", failedCond.Reason, "RevisionFailed")
+	}
+}

--- a/pkg/reconciler/wasmmodule/reconciler_test.go
+++ b/pkg/reconciler/wasmmodule/reconciler_test.go
@@ -18,6 +18,7 @@ package wasmmodule_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	api "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
@@ -36,11 +37,11 @@ import (
 // fakeTracker is a no-op tracker for unit tests.
 type fakeTracker struct{}
 
-func (fakeTracker) Track(ref corev1.ObjectReference, obj interface{}) error     { return nil }
-func (fakeTracker) TrackReference(ref tracker.Reference, obj interface{}) error { return nil }
-func (fakeTracker) OnChanged(obj interface{})                                   {}
-func (fakeTracker) GetObservers(obj interface{}) []types.NamespacedName         { return nil }
-func (fakeTracker) OnDeletedObserver(obj interface{})                           {}
+func (fakeTracker) Track(_ corev1.ObjectReference, _ interface{}) error     { return nil }
+func (fakeTracker) TrackReference(_ tracker.Reference, _ interface{}) error { return nil }
+func (fakeTracker) OnChanged(_ interface{})                                 {}
+func (fakeTracker) GetObservers(_ interface{}) []types.NamespacedName       { return nil }
+func (fakeTracker) OnDeletedObserver(_ interface{})                         {}
 
 // buildServiceLister creates a ServiceLister seeded with the given services.
 func buildServiceLister(svcs ...*servingv1.Service) servingv1listers.ServiceLister {
@@ -103,6 +104,37 @@ func ksvcWithReadyUnknown(namespace, name string) *servingv1.Service {
 	}
 }
 
+// assertCondition runs ReconcileKind and validates the Ready condition.
+func assertCondition(
+	t *testing.T,
+	r *wasmmodule.Reconciler,
+	module *api.WasmModule,
+	wantReason, wantMessage string,
+) {
+	t.Helper()
+
+	if err := r.ReconcileKind(context.Background(), module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	cond := module.Status.GetCondition(apis.ConditionReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition, got nil")
+	}
+
+	if !cond.IsFalse() {
+		t.Errorf("expected condition to be False, got %v", cond.Status)
+	}
+
+	if cond.Reason != wantReason {
+		t.Errorf("reason: got %q, want %q", cond.Reason, wantReason)
+	}
+
+	if cond.Message != wantMessage {
+		t.Errorf("message: got %q, want %q", cond.Message, wantMessage)
+	}
+}
+
 func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
 	t.Parallel()
 
@@ -134,6 +166,7 @@ func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
 			t.Parallel()
 
 			const ns = "default"
+
 			const moduleName = "my-wasm"
 
 			svc := ksvcWithConfigFailed(ns, moduleName, tt.svcReason, tt.svcMessage)
@@ -154,26 +187,7 @@ func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
 			}
 			module.Status.InitializeConditions()
 
-			if err := r.ReconcileKind(context.Background(), module); err != nil {
-				t.Fatalf("ReconcileKind() error: %v", err)
-			}
-
-			cond := module.Status.GetCondition(apis.ConditionReady)
-			if cond == nil {
-				t.Fatal("expected Ready condition, got nil")
-			}
-
-			if !cond.IsFalse() {
-				t.Errorf("expected condition to be False, got %v", cond.Status)
-			}
-
-			if cond.Reason != tt.wantReason {
-				t.Errorf("reason: got %q, want %q", cond.Reason, tt.wantReason)
-			}
-
-			if cond.Message != tt.wantMessage {
-				t.Errorf("message: got %q, want %q", cond.Message, tt.wantMessage)
-			}
+			assertCondition(t, r, module, tt.wantReason, tt.wantMessage)
 		})
 	}
 }
@@ -182,6 +196,7 @@ func TestReconcileKind_TransientNotReady(t *testing.T) {
 	t.Parallel()
 
 	const ns = "default"
+
 	const moduleName = "my-wasm"
 
 	svc := ksvcWithReadyUnknown(ns, moduleName)
@@ -202,21 +217,8 @@ func TestReconcileKind_TransientNotReady(t *testing.T) {
 	}
 	module.Status.InitializeConditions()
 
-	if err := r.ReconcileKind(context.Background(), module); err != nil {
-		t.Fatalf("ReconcileKind() error: %v", err)
-	}
-
-	cond := module.Status.GetCondition(apis.ConditionReady)
-	if cond == nil {
-		t.Fatal("expected Ready condition, got nil")
-	}
-
-	if !cond.IsFalse() {
-		t.Errorf("expected condition to be False, got %v", cond.Status)
-	}
-
-	// Transient: should be ServiceUnavailable, NOT RevisionFailed
-	if cond.Reason != "ServiceUnavailable" {
-		t.Errorf("reason: got %q, want %q", cond.Reason, "ServiceUnavailable")
-	}
+	// Transient: should be ServiceUnavailable, NOT RevisionFailed.
+	// MarkServiceUnavailable formats the message as: Service %q wasn't found.
+	wantMsg := fmt.Sprintf("Service %q wasn't found.", moduleName)
+	assertCondition(t, r, module, "ServiceUnavailable", wantMsg)
 }

--- a/pkg/reconciler/wasmmodule/reconciler_test.go
+++ b/pkg/reconciler/wasmmodule/reconciler_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wasmmodule_test
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
+	"github.com/cardil/knative-serving-wasm/pkg/reconciler/wasmmodule"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/tracker"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	servingv1listers "knative.dev/serving/pkg/client/listers/serving/v1"
+)
+
+// fakeTracker is a no-op tracker for unit tests.
+type fakeTracker struct{}
+
+func (fakeTracker) Track(ref corev1.ObjectReference, obj interface{}) error     { return nil }
+func (fakeTracker) TrackReference(ref tracker.Reference, obj interface{}) error { return nil }
+func (fakeTracker) OnChanged(obj interface{})                                   {}
+func (fakeTracker) GetObservers(obj interface{}) []types.NamespacedName         { return nil }
+func (fakeTracker) OnDeletedObserver(obj interface{})                           {}
+
+// buildServiceLister creates a ServiceLister seeded with the given services.
+func buildServiceLister(svcs ...*servingv1.Service) servingv1listers.ServiceLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, svc := range svcs {
+		_ = indexer.Add(svc)
+	}
+
+	return servingv1listers.NewServiceLister(indexer)
+}
+
+// ksvcWithConfigFailed returns a Knative Service with ConfigurationsReady=False.
+func ksvcWithConfigFailed(namespace, name, reason, message string) *servingv1.Service {
+	return &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: servingv1.ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:    apis.ConditionReady,
+						Status:  corev1.ConditionFalse,
+						Reason:  reason,
+						Message: message,
+					},
+					{
+						Type:    servingv1.ConfigurationConditionReady,
+						Status:  corev1.ConditionFalse,
+						Reason:  reason,
+						Message: message,
+					},
+				},
+			},
+		},
+	}
+}
+
+// ksvcWithReadyUnknown returns a Knative Service that is still reconciling
+// (Ready=Unknown, no ConfigurationsReady=False).
+func ksvcWithReadyUnknown(namespace, name string) *servingv1.Service {
+	return &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: servingv1.ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:   apis.ConditionReady,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		svcReason   string
+		svcMessage  string
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "RevisionFailed propagated to WasmModule",
+			svcReason:   "RevisionFailed",
+			svcMessage:  "Revision 'foo-00001' failed with message: OCI pull failed.",
+			wantReason:  "RevisionFailed",
+			wantMessage: "Revision 'foo-00001' failed with message: OCI pull failed.",
+		},
+		{
+			name:        "ContainerMissing propagated to WasmModule",
+			svcReason:   "ContainerMissing",
+			svcMessage:  "Image not found.",
+			wantReason:  "ContainerMissing",
+			wantMessage: "Image not found.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const ns = "default"
+			const moduleName = "my-wasm"
+
+			svc := ksvcWithConfigFailed(ns, moduleName, tt.svcReason, tt.svcMessage)
+
+			r := &wasmmodule.Reconciler{
+				Tracker:       fakeTracker{},
+				ServiceLister: buildServiceLister(svc),
+			}
+
+			module := &api.WasmModule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: ns,
+				},
+				Spec: api.WasmModuleSpec{
+					Image: "example.com/img:latest",
+				},
+			}
+			module.Status.InitializeConditions()
+
+			if err := r.ReconcileKind(context.Background(), module); err != nil {
+				t.Fatalf("ReconcileKind() error: %v", err)
+			}
+
+			cond := module.Status.GetCondition(apis.ConditionReady)
+			if cond == nil {
+				t.Fatal("expected Ready condition, got nil")
+			}
+
+			if !cond.IsFalse() {
+				t.Errorf("expected condition to be False, got %v", cond.Status)
+			}
+
+			if cond.Reason != tt.wantReason {
+				t.Errorf("reason: got %q, want %q", cond.Reason, tt.wantReason)
+			}
+
+			if cond.Message != tt.wantMessage {
+				t.Errorf("message: got %q, want %q", cond.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestReconcileKind_TransientNotReady(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+	const moduleName = "my-wasm"
+
+	svc := ksvcWithReadyUnknown(ns, moduleName)
+
+	r := &wasmmodule.Reconciler{
+		Tracker:       fakeTracker{},
+		ServiceLister: buildServiceLister(svc),
+	}
+
+	module := &api.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      moduleName,
+			Namespace: ns,
+		},
+		Spec: api.WasmModuleSpec{
+			Image: "example.com/img:latest",
+		},
+	}
+	module.Status.InitializeConditions()
+
+	if err := r.ReconcileKind(context.Background(), module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	cond := module.Status.GetCondition(apis.ConditionReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition, got nil")
+	}
+
+	if !cond.IsFalse() {
+		t.Errorf("expected condition to be False, got %v", cond.Status)
+	}
+
+	// Transient: should be ServiceUnavailable, NOT RevisionFailed
+	if cond.Reason != "ServiceUnavailable" {
+		t.Errorf("reason: got %q, want %q", cond.Reason, "ServiceUnavailable")
+	}
+}

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -121,7 +121,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, module *api.WasmModule) 
 			}
 		}
 	} else {
-		module.Status.MarkServiceUnavailable(serviceName)
+		// Check for a terminal Configuration failure (e.g. RevisionFailed, ContainerMissing)
+		// so that clients can distinguish transient "not ready yet" from permanent failures.
+		cfgCond := srv.Status.GetCondition(servingv1.ConfigurationConditionReady)
+		if cfgCond != nil && cfgCond.IsFalse() {
+			module.Status.MarkServiceFailed(cfgCond.Reason, cfgCond.Message)
+		} else {
+			module.Status.MarkServiceUnavailable(serviceName)
+		}
 	}
 
 	return nil

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -135,6 +135,87 @@ func (tc *TestContext) WaitForWasmModuleReady(
 	)
 }
 
+// SetProgressDeadline patches the Knative config-deployment configmap to use the
+// given progress-deadline (e.g. "30s") so that revision failures are detected faster.
+// Returns the previous value so callers can restore it.
+func (tc *TestContext) SetProgressDeadline(ctx context.Context, duration string) (string, error) {
+	cm, err := tc.KubeClient.CoreV1().ConfigMaps("knative-serving").Get(
+		ctx, "config-deployment", metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("get config-deployment: %w", err)
+	}
+
+	prev := cm.Data["progress-deadline"]
+
+	cm = cm.DeepCopy()
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
+	cm.Data["progress-deadline"] = duration
+
+	_, err = tc.KubeClient.CoreV1().ConfigMaps("knative-serving").Update(
+		ctx, cm, metav1.UpdateOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("update config-deployment: %w", err)
+	}
+
+	tc.T.Logf("Set Knative progress-deadline to %s (was %q)", duration, prev)
+
+	return prev, nil
+}
+
+// WaitForWasmModuleTerminalFailure waits until the WasmModule has Ready=False
+// with a reason other than "ServiceUnavailable" (which is transient).
+// Use this to verify terminal failure propagation from the underlying ksvc.
+func (tc *TestContext) WaitForWasmModuleTerminalFailure(
+	ctx context.Context, name string,
+) (string, error) {
+	tc.T.Logf("Waiting for WasmModule %s to reach terminal failure...", name)
+
+	var gotReason string
+
+	pollFn := func(ctx context.Context) (bool, error) {
+		wm, err := tc.WasmClient.WasmV1alpha1().WasmModules(
+			tc.Namespace,
+		).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range wm.Status.Conditions {
+			if cond.Type != "Ready" {
+				continue
+			}
+
+			if cond.Status == "False" {
+				tc.T.Logf("WasmModule %s: Ready=False, Reason=%s, Message=%s",
+					name, cond.Reason, cond.Message)
+
+				// ServiceUnavailable is transient — keep waiting for ksvc to be reconciled
+				if cond.Reason == "ServiceUnavailable" {
+					return false, nil
+				}
+
+				// Any other False reason is a terminal failure from the ksvc
+				gotReason = cond.Reason
+
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	err := wait.PollUntilContextTimeout(
+		ctx, DefaultPollInterval, DefaultTimeout, true, pollFn,
+	)
+
+	return gotReason, err
+}
+
 // GetWasmModuleURL returns the URL for accessing a WasmModule.
 func (tc *TestContext) GetWasmModuleURL(
 	ctx context.Context, name string,

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -194,12 +194,13 @@ func (tc *TestContext) WaitForWasmModuleTerminalFailure(
 				tc.T.Logf("WasmModule %s: Ready=False, Reason=%s, Message=%s",
 					name, cond.Reason, cond.Message)
 
-				// ServiceUnavailable is transient — keep waiting for ksvc to be reconciled
-				if cond.Reason == "ServiceUnavailable" {
+				// Skip empty reason or ServiceUnavailable (both are transient states —
+				// the controller hasn't set a terminal reason yet).
+				if cond.Reason == "" || cond.Reason == "ServiceUnavailable" {
 					return false, nil
 				}
 
-				// Any other False reason is a terminal failure from the ksvc
+				// Any other non-empty False reason is a terminal failure from the ksvc
 				gotReason = cond.Reason
 
 				return true, nil

--- a/test/e2e/wasmmodule_test.go
+++ b/test/e2e/wasmmodule_test.go
@@ -121,14 +121,9 @@ func TestTerminalFailurePropagation(t *testing.T) {
 
 // withProgressDeadline sets the Knative progress-deadline to the given value,
 // calls fn, and restores the original value regardless of fn's outcome.
-// A non-cancellable context with its own timeout is used for the restore step
-// so that cleanup succeeds even if the test context has already been cancelled.
+// A non-cancellable context with its own timeout is created after fn returns
+// so the 30s restore window starts only when cleanup begins (not before fn runs).
 func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string, fn func() error) error {
-	// Capture a non-cancellable, deadline-bounded context for the restore step
-	// before running fn, so cleanup is independent of the test context's lifetime.
-	restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-	defer restoreCancel()
-
 	prev, err := tc.SetProgressDeadline(ctx, deadline)
 	if err != nil {
 		return fmt.Errorf("set progress deadline: %w", err)
@@ -139,6 +134,11 @@ func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string,
 	if prev == "" {
 		prev = "600s"
 	}
+
+	// Create the restore context only after fn() finishes so its 30s timeout
+	// does not start ticking while fn() is still running.
+	restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer restoreCancel()
 
 	_, restoreErr := tc.SetProgressDeadline(restoreCtx, prev)
 

--- a/test/e2e/wasmmodule_test.go
+++ b/test/e2e/wasmmodule_test.go
@@ -17,12 +17,14 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 
 	wasmv1alpha1 "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
 )
@@ -88,6 +90,87 @@ func TestBasicDeployment(t *testing.T) {
 	}
 
 	t.Logf("Successfully verified reverse-text response: %s", response)
+}
+
+// TestTerminalFailurePropagation verifies that when the underlying Knative Service
+// fails permanently (e.g. RevisionFailed due to a bad image), the WasmModule status
+// reflects a terminal failure reason instead of the generic ServiceUnavailable.
+// This ensures clients (e.g. func deploy) can distinguish transient from permanent failures.
+func TestTerminalFailurePropagation(t *testing.T) {
+	ctx := t.Context()
+	namespace := fmt.Sprintf("e2e-terminal-%d", time.Now().Unix())
+
+	tc, err := newTestContext(ctx, t, namespace)
+	if err != nil {
+		t.Fatalf("Failed to create test context: %v", err)
+	}
+	defer tc.Cleanup()
+
+	if err := tc.CreateNamespace(ctx); err != nil {
+		t.Fatalf("Failed to create namespace: %v", err)
+	}
+
+	// Speed up Knative's progress deadline so failures are detected quickly.
+	// Restore the original value after the test.
+	prev, err := tc.SetProgressDeadline(ctx, "5s")
+	if err != nil {
+		t.Fatalf("Failed to set progress deadline: %v", err)
+	}
+
+	defer func() {
+		if prev == "" {
+			prev = "600s"
+		}
+
+		if _, restoreErr := tc.SetProgressDeadline(context.Background(), prev); restoreErr != nil {
+			t.Logf("Warning: failed to restore progress deadline: %v", restoreErr)
+		}
+	}()
+
+	// Use a deliberately invalid runner image to trigger a terminal revision failure.
+	// The runner is the container image (not the WASM image), so using a non-existent
+	// runner image causes Knative to set ConfigurationsReady=False/RevisionFailed.
+	wasmModule := &wasmv1alpha1.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-image",
+			Namespace: namespace,
+		},
+		Spec: wasmv1alpha1.WasmModuleSpec{
+			Image: "example.com/this-image-does-not-exist:latest",
+		},
+	}
+
+	if _, err = tc.CreateWasmModule(ctx, wasmModule); err != nil {
+		t.Fatalf("Failed to create WasmModule: %v", err)
+	}
+
+	// Wait for WasmModule to reach a terminal failure (any reason other than ServiceUnavailable).
+	// Knative sets ConfigurationsReady=False with reason=RevisionFailed or ProgressDeadlineExceeded
+	// once it determines no revision can become ready.
+	gotReason, err := tc.WaitForWasmModuleTerminalFailure(ctx, "bad-image")
+	if err != nil {
+		t.Fatalf("WasmModule did not reach terminal failure within timeout: %v", err)
+	}
+
+	// Verify the condition is set to terminal failure (not ServiceUnavailable)
+	wm, err := tc.WasmClient.WasmV1alpha1().WasmModules(
+		namespace,
+	).Get(ctx, "bad-image", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get WasmModule: %v", err)
+	}
+
+	cond := wm.Status.GetCondition(apis.ConditionReady)
+	if cond == nil {
+		t.Fatal("WasmModule has no Ready condition")
+	}
+
+	if cond.Reason == "ServiceUnavailable" {
+		t.Errorf("Ready condition reason is ServiceUnavailable (transient); want a terminal reason (e.g. RevisionFailed, ProgressDeadlineExceeded)")
+	}
+
+	t.Logf("Terminal failure correctly propagated: Ready=False, Reason=%s (gotReason=%s), Message=%s",
+		cond.Reason, gotReason, cond.Message)
 }
 
 // reverseString reverses a string.

--- a/test/e2e/wasmmodule_test.go
+++ b/test/e2e/wasmmodule_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -110,23 +111,36 @@ func TestTerminalFailurePropagation(t *testing.T) {
 		t.Fatalf("Failed to create namespace: %v", err)
 	}
 
-	// Speed up Knative's progress deadline so failures are detected quickly.
-	// Restore the original value after the test.
-	prev, err := tc.SetProgressDeadline(ctx, "5s")
+	// Run the body with a short progress-deadline so failures are detected in seconds.
+	if err := withProgressDeadline(ctx, tc, "5s", func() error {
+		return runTerminalFailureTest(ctx, tc, namespace)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// withProgressDeadline sets the Knative progress-deadline to the given value,
+// calls fn, and restores the original value regardless of fn's outcome.
+func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string, fn func() error) error {
+	prev, err := tc.SetProgressDeadline(ctx, deadline)
 	if err != nil {
-		t.Fatalf("Failed to set progress deadline: %v", err)
+		return fmt.Errorf("set progress deadline: %w", err)
 	}
 
-	defer func() {
-		if prev == "" {
-			prev = "600s"
-		}
+	fnErr := fn()
 
-		if _, restoreErr := tc.SetProgressDeadline(context.Background(), prev); restoreErr != nil {
-			t.Logf("Warning: failed to restore progress deadline: %v", restoreErr)
-		}
-	}()
+	if prev == "" {
+		prev = "600s"
+	}
 
+	_, restoreErr := tc.SetProgressDeadline(ctx, prev)
+
+	return errors.Join(fnErr, restoreErr)
+}
+
+// runTerminalFailureTest creates a WasmModule with a bad image and asserts
+// that the controller propagates a terminal failure reason (not ServiceUnavailable).
+func runTerminalFailureTest(ctx context.Context, tc *TestContext, namespace string) error {
 	// Use a deliberately invalid runner image to trigger a terminal revision failure.
 	// The runner is the container image (not the WASM image), so using a non-existent
 	// runner image causes Knative to set ConfigurationsReady=False/RevisionFailed.
@@ -140,8 +154,8 @@ func TestTerminalFailurePropagation(t *testing.T) {
 		},
 	}
 
-	if _, err = tc.CreateWasmModule(ctx, wasmModule); err != nil {
-		t.Fatalf("Failed to create WasmModule: %v", err)
+	if _, err := tc.CreateWasmModule(ctx, wasmModule); err != nil {
+		return fmt.Errorf("create WasmModule: %w", err)
 	}
 
 	// Wait for WasmModule to reach a terminal failure (any reason other than ServiceUnavailable).
@@ -149,28 +163,36 @@ func TestTerminalFailurePropagation(t *testing.T) {
 	// once it determines no revision can become ready.
 	gotReason, err := tc.WaitForWasmModuleTerminalFailure(ctx, "bad-image")
 	if err != nil {
-		t.Fatalf("WasmModule did not reach terminal failure within timeout: %v", err)
+		return fmt.Errorf("WasmModule did not reach terminal failure within timeout: %w", err)
 	}
 
-	// Verify the condition is set to terminal failure (not ServiceUnavailable)
+	return checkTerminalCondition(ctx, tc, namespace, gotReason)
+}
+
+// checkTerminalCondition fetches the WasmModule and verifies its Ready condition
+// is a terminal failure (reason ≠ ServiceUnavailable).
+func checkTerminalCondition(ctx context.Context, tc *TestContext, namespace, gotReason string) error {
 	wm, err := tc.WasmClient.WasmV1alpha1().WasmModules(
 		namespace,
 	).Get(ctx, "bad-image", metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get WasmModule: %v", err)
+		return fmt.Errorf("get WasmModule: %w", err)
 	}
 
 	cond := wm.Status.GetCondition(apis.ConditionReady)
 	if cond == nil {
-		t.Fatal("WasmModule has no Ready condition")
+		return errors.New("WasmModule has no Ready condition")
 	}
 
 	if cond.Reason == "ServiceUnavailable" {
-		t.Errorf("Ready condition reason is ServiceUnavailable (transient); want a terminal reason (e.g. RevisionFailed, ProgressDeadlineExceeded)")
+		return fmt.Errorf(
+			"Ready condition reason is ServiceUnavailable (transient);"+
+				" want a terminal reason (e.g. RevisionFailed, ProgressDeadlineExceeded),"+
+				" gotReason=%s", gotReason,
+		)
 	}
 
-	t.Logf("Terminal failure correctly propagated: Ready=False, Reason=%s (gotReason=%s), Message=%s",
-		cond.Reason, gotReason, cond.Message)
+	return nil
 }
 
 // reverseString reverses a string.

--- a/test/e2e/wasmmodule_test.go
+++ b/test/e2e/wasmmodule_test.go
@@ -120,29 +120,30 @@ func TestTerminalFailurePropagation(t *testing.T) {
 }
 
 // withProgressDeadline sets the Knative progress-deadline to the given value,
-// calls fn, and restores the original value regardless of fn's outcome.
-// A non-cancellable context with its own timeout is created after fn returns
-// so the 30s restore window starts only when cleanup begins (not before fn runs).
-func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string, fn func() error) error {
+// calls fn, and restores the original value regardless of fn's outcome (including panics).
+// The restore context is created inside the deferred closure so its 30s timeout
+// starts only when cleanup begins, not before fn runs.
+func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string, fn func() error) (retErr error) {
 	prev, err := tc.SetProgressDeadline(ctx, deadline)
 	if err != nil {
 		return fmt.Errorf("set progress deadline: %w", err)
 	}
 
-	fnErr := fn()
-
 	if prev == "" {
 		prev = "600s"
 	}
 
-	// Create the restore context only after fn() finishes so its 30s timeout
-	// does not start ticking while fn() is still running.
-	restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-	defer restoreCancel()
+	defer func() {
+		// Create the restore context only when cleanup begins so its 30s
+		// timeout does not tick while fn() is running.
+		restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer restoreCancel()
 
-	_, restoreErr := tc.SetProgressDeadline(restoreCtx, prev)
+		_, restoreErr := tc.SetProgressDeadline(restoreCtx, prev)
+		retErr = errors.Join(retErr, restoreErr)
+	}()
 
-	return errors.Join(fnErr, restoreErr)
+	return fn()
 }
 
 // runTerminalFailureTest creates a WasmModule with a bad image and asserts
@@ -191,11 +192,26 @@ func checkTerminalCondition(ctx context.Context, tc *TestContext, namespace, got
 		return errors.New("WasmModule has no Ready condition")
 	}
 
+	if cond.Status != "False" {
+		return fmt.Errorf("Ready condition status=%s, want False", cond.Status)
+	}
+
+	if cond.Reason == "" {
+		return errors.New("Ready condition reason is empty; want a terminal reason")
+	}
+
 	if cond.Reason == "ServiceUnavailable" {
 		return fmt.Errorf(
 			"Ready condition reason is ServiceUnavailable (transient);"+
 				" want a terminal reason (e.g. RevisionFailed, ProgressDeadlineExceeded),"+
 				" gotReason=%s", gotReason,
+		)
+	}
+
+	if gotReason != "" && cond.Reason != gotReason {
+		return fmt.Errorf(
+			"Ready condition reason changed after terminal detection: got=%s want=%s",
+			cond.Reason, gotReason,
 		)
 	}
 

--- a/test/e2e/wasmmodule_test.go
+++ b/test/e2e/wasmmodule_test.go
@@ -121,7 +121,14 @@ func TestTerminalFailurePropagation(t *testing.T) {
 
 // withProgressDeadline sets the Knative progress-deadline to the given value,
 // calls fn, and restores the original value regardless of fn's outcome.
+// A non-cancellable context with its own timeout is used for the restore step
+// so that cleanup succeeds even if the test context has already been cancelled.
 func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string, fn func() error) error {
+	// Capture a non-cancellable, deadline-bounded context for the restore step
+	// before running fn, so cleanup is independent of the test context's lifetime.
+	restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer restoreCancel()
+
 	prev, err := tc.SetProgressDeadline(ctx, deadline)
 	if err != nil {
 		return fmt.Errorf("set progress deadline: %w", err)
@@ -133,7 +140,7 @@ func withProgressDeadline(ctx context.Context, tc *TestContext, deadline string,
 		prev = "600s"
 	}
 
-	_, restoreErr := tc.SetProgressDeadline(ctx, prev)
+	_, restoreErr := tc.SetProgressDeadline(restoreCtx, prev)
 
 	return errors.Join(fnErr, restoreErr)
 }


### PR DESCRIPTION
## Summary

Fixes #19 — WasmModule controller always sets `ServiceUnavailable` even on permanent ksvc failure.

## Changes

- Added `MarkServiceFailed(reason, message string)` to lifecycle helpers
- Updated `ReconcileKind` else-branch to inspect `ConfigurationConditionReady` before falling back to generic `MarkServiceUnavailable`
- Terminal failures (e.g. `RevisionFailed`, `ContainerMissing`) now propagate the actual reason and message
- Transient not-ready states still use `ServiceUnavailable` as before

## Tests

- Unit tests: `wasm_module_lifecycle_test.go` and `reconciler_test.go` (new files)
- E2E test: `TestTerminalFailurePropagation` — deploys a WasmModule with a bad image, sets progress-deadline to 5s, and asserts the final reason is not `ServiceUnavailable`
- All 6 e2e tests passed 3 times consecutively

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates terminal Knative Service failures to the `WasmModule` status so users see the real reason (e.g., `RevisionFailed`, `ContainerMissing`) instead of `ServiceUnavailable`. Hardens e2e tests to avoid false positives and ensure config restore even if tests fail.

- **Bug Fixes**
  - Added `MarkServiceFailed(reason, message)` to set a permanent failure on `WasmModule`.
  - Reconciler inspects `servingv1.ConfigurationConditionReady`; if False, calls `MarkServiceFailed`, otherwise keeps `ServiceUnavailable`.
  - Hardened e2e: `progress-deadline` helper uses panic-safe restore with `context.WithoutCancel` + timeout; guarded empty Ready reason; `checkTerminalCondition` now validates status, non-empty reason, and reason consistency; restore timeout starts after the test body.

- **Refactors**
  - Cleaned up tests for readability: extracted `assertCondition` and `withProgressDeadline`, renamed unused params, and used `errors.Join`/`errors.New`.

<sup>Written for commit d5e43bfaef973e04cbd8bf4d5dc5eb3b23970474. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status now records and surfaces terminal service failure reasons and messages (instead of always reporting transient unavailability), and reconciliation uses the service configuration’s ready state to distinguish terminal vs transient failures.

* **Tests**
  * Added unit tests covering terminal vs transient service failure handling.
  * Added end-to-end test and helpers to shorten progress deadlines and detect/validate terminal failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->