### PR TITLE
feat: support insecure OCI registries via INSECURE_REGISTRIES env var (#18)

### DIFF
--- a/config/config-runner.yaml
+++ b/config/config-runner.yaml
@@ -1,0 +1,51 @@
+# Copyright 2026 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-runner
+  namespace: knative-wasm
+  labels:
+    wasm.serving.knative.dev/release: devel
+
+data:
+  # insecure-registries is a YAML list of registry hostnames (host[:port])
+  # that the runner will access over plain HTTP instead of HTTPS.
+  # Default is empty (all registries require HTTPS).
+  insecure-registries: ""
+
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # insecure-registries is a YAML list of OCI registry hosts (host[:port])
+    # that should be accessed over plain HTTP instead of HTTPS.
+    # This is useful for development environments with local registries.
+    # WARNING: Using insecure registries in production is a security risk.
+    insecure-registries: |
+      - registry.local:5000
+      - my-registry.internal:5000

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/joho/godotenv v1.5.1
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
@@ -90,7 +91,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/code-generator v0.35.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect

--- a/pkg/reconciler/wasmmodule/controller.go
+++ b/pkg/reconciler/wasmmodule/controller.go
@@ -33,15 +33,19 @@ import (
 // NewController creates a Reconciler and returns the result of NewImpl.
 func NewController(
 	ctx context.Context,
-	_ configmap.Watcher,
+	cmw configmap.Watcher,
 ) *controller.Impl {
 	log := logging.FromContext(ctx)
 	wasmmoduleInformer := wasmmoduleinformer.Get(ctx)
 	svcInformer := svcinformer.Get(ctx)
 
+	runnerConfigStore := NewRunnerConfigStore(logging.FromContext(ctx).Named("runner-config-store"))
+	runnerConfigStore.WatchConfigs(cmw)
+
 	reconciler := &Reconciler{
-		ServiceLister: svcInformer.Lister(),
-		Client:        svcclient.Get(ctx).ServingV1(),
+		ServiceLister:     svcInformer.Lister(),
+		Client:            svcclient.Get(ctx).ServingV1(),
+		RunnerConfigStore: runnerConfigStore,
 	}
 	impl := wasmmodulereconciler.NewImpl(ctx, reconciler)
 	reconciler.Tracker = impl.Tracker

--- a/pkg/reconciler/wasmmodule/runner_config.go
+++ b/pkg/reconciler/wasmmodule/runner_config.go
@@ -75,7 +75,7 @@ func NewRunnerConfigStore(logger configmap.Logger) *RunnerConfigStore {
 
 // GetRunnerConfig fetches the current RunnerConfig from the store.
 func (s *RunnerConfigStore) GetRunnerConfig() *RunnerConfig {
-	cfg, ok := s.UntypedStore.UntypedLoad(RunnerConfigName).(*RunnerConfig)
+	cfg, ok := s.UntypedLoad(RunnerConfigName).(*RunnerConfig)
 	if !ok || cfg == nil {
 		return &RunnerConfig{}
 	}

--- a/pkg/reconciler/wasmmodule/runner_config.go
+++ b/pkg/reconciler/wasmmodule/runner_config.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wasmmodule
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/configmap"
+)
+
+const (
+	// RunnerConfigName is the name of the ConfigMap containing runner configuration.
+	RunnerConfigName = "config-runner"
+)
+
+// RunnerConfig holds the runner-level configuration read from the config-runner ConfigMap.
+type RunnerConfig struct {
+	// InsecureRegistries is the list of registry host[:port] entries that the
+	// runner should access over plain HTTP instead of HTTPS.
+	InsecureRegistries []string
+}
+
+// NewRunnerConfigFromConfigMap creates a RunnerConfig from the given ConfigMap.
+func NewRunnerConfigFromConfigMap(cm *corev1.ConfigMap) (*RunnerConfig, error) {
+	cfg := &RunnerConfig{}
+
+	raw, ok := cm.Data["insecure-registries"]
+	if !ok || raw == "" {
+		return cfg, nil
+	}
+
+	var registries []string
+	if err := yaml.Unmarshal([]byte(raw), &registries); err != nil {
+		return nil, fmt.Errorf("failed to parse insecure-registries from %s ConfigMap: %w", RunnerConfigName, err)
+	}
+
+	cfg.InsecureRegistries = registries
+
+	return cfg, nil
+}
+
+// RunnerConfigStore is a store for the runner configuration.
+type RunnerConfigStore struct {
+	*configmap.UntypedStore
+}
+
+// NewRunnerConfigStore creates a new RunnerConfigStore.
+func NewRunnerConfigStore(logger configmap.Logger) *RunnerConfigStore {
+	return &RunnerConfigStore{
+		UntypedStore: configmap.NewUntypedStore(
+			"runner",
+			logger,
+			configmap.Constructors{
+				RunnerConfigName: NewRunnerConfigFromConfigMap,
+			},
+		),
+	}
+}
+
+// GetRunnerConfig fetches the current RunnerConfig from the store.
+func (s *RunnerConfigStore) GetRunnerConfig() *RunnerConfig {
+	cfg, ok := s.UntypedStore.UntypedLoad(RunnerConfigName).(*RunnerConfig)
+	if !ok || cfg == nil {
+		return &RunnerConfig{}
+	}
+
+	return cfg
+}

--- a/pkg/reconciler/wasmmodule/runner_config_test.go
+++ b/pkg/reconciler/wasmmodule/runner_config_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wasmmodule_test
+
+import (
+	"testing"
+
+	"github.com/cardil/knative-serving-wasm/pkg/reconciler/wasmmodule"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRunnerConfigFromConfigMap_Empty(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data:       map[string]string{},
+	}
+
+	cfg, err := wasmmodule.NewRunnerConfigFromConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.InsecureRegistries) != 0 {
+		t.Errorf("expected empty InsecureRegistries, got %v", cfg.InsecureRegistries)
+	}
+}
+
+func TestNewRunnerConfigFromConfigMap_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data: map[string]string{
+			"insecure-registries": "",
+		},
+	}
+
+	cfg, err := wasmmodule.NewRunnerConfigFromConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.InsecureRegistries) != 0 {
+		t.Errorf("expected empty InsecureRegistries, got %v", cfg.InsecureRegistries)
+	}
+}
+
+func TestNewRunnerConfigFromConfigMap_SingleEntry(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data: map[string]string{
+			"insecure-registries": "- registry.local:5000\n",
+		},
+	}
+
+	cfg, err := wasmmodule.NewRunnerConfigFromConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.InsecureRegistries) != 1 {
+		t.Fatalf("expected 1 InsecureRegistry, got %d", len(cfg.InsecureRegistries))
+	}
+
+	if cfg.InsecureRegistries[0] != "registry.local:5000" {
+		t.Errorf("expected registry.local:5000, got %s", cfg.InsecureRegistries[0])
+	}
+}
+
+func TestNewRunnerConfigFromConfigMap_MultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data: map[string]string{
+			"insecure-registries": "- registry.local:5000\n- my-registry.internal:5000\n",
+		},
+	}
+
+	cfg, err := wasmmodule.NewRunnerConfigFromConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.InsecureRegistries) != 2 {
+		t.Fatalf("expected 2 InsecureRegistries, got %d", len(cfg.InsecureRegistries))
+	}
+
+	if cfg.InsecureRegistries[0] != "registry.local:5000" {
+		t.Errorf("expected registry.local:5000, got %s", cfg.InsecureRegistries[0])
+	}
+
+	if cfg.InsecureRegistries[1] != "my-registry.internal:5000" {
+		t.Errorf("expected my-registry.internal:5000, got %s", cfg.InsecureRegistries[1])
+	}
+}
+
+func TestNewRunnerConfigFromConfigMap_MalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data: map[string]string{
+			"insecure-registries": "key: {broken: yaml: [",
+		},
+	}
+
+	_, err := wasmmodule.NewRunnerConfigFromConfigMap(cm)
+	if err == nil {
+		t.Error("expected error for malformed YAML, got nil")
+	}
+}
+
+func TestMatchesInsecureRegistry_Matching(t *testing.T) {
+	t.Parallel()
+
+	registries := []string{"registry.local:5000", "my-registry.internal:5000"}
+
+	tests := []struct {
+		image string
+		want  bool
+	}{
+		{"registry.local:5000/mymodule:latest", true},
+		{"my-registry.internal:5000/img:v1", true},
+		{"ghcr.io/example/module:latest", false},
+		{"docker.io/library/nginx:latest", false},
+	}
+
+	for _, tt := range tests {
+		got := wasmmodule.MatchesInsecureRegistry(tt.image, registries)
+		if got != tt.want {
+			t.Errorf("MatchesInsecureRegistry(%q, %v) = %v, want %v", tt.image, registries, got, tt.want)
+		}
+	}
+}

--- a/pkg/reconciler/wasmmodule/runner_config_test.go
+++ b/pkg/reconciler/wasmmodule/runner_config_test.go
@@ -133,7 +133,7 @@ func TestNewRunnerConfigFromConfigMap_MalformedYAML(t *testing.T) {
 func TestMatchesInsecureRegistry_Matching(t *testing.T) {
 	t.Parallel()
 
-	registries := []string{"registry.local:5000", "my-registry.internal:5000"}
+	registries := []string{"registry.local:5000", "my-registry.internal:5000", "localhost"}
 
 	tests := []struct {
 		image string
@@ -141,6 +141,8 @@ func TestMatchesInsecureRegistry_Matching(t *testing.T) {
 	}{
 		{"registry.local:5000/mymodule:latest", true},
 		{"my-registry.internal:5000/img:v1", true},
+		{"localhost/my-module:latest", true},
+		{"oci://localhost/my-module:v2", true},
 		{"ghcr.io/example/module:latest", false},
 		{"docker.io/library/nginx:latest", false},
 	}

--- a/pkg/reconciler/wasmmodule/runner_config_test.go
+++ b/pkg/reconciler/wasmmodule/runner_config_test.go
@@ -143,6 +143,7 @@ func TestMatchesInsecureRegistry_Matching(t *testing.T) {
 		{"my-registry.internal:5000/img:v1", true},
 		{"localhost/my-module:latest", true},
 		{"oci://localhost/my-module:v2", true},
+		{"OCI://registry.local:5000/mymodule:latest", true},
 		{"ghcr.io/example/module:latest", false},
 		{"docker.io/library/nginx:latest", false},
 	}

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -139,6 +139,42 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, module *api.WasmModule) 
 	return nil
 }
 
+// buildEnvVars builds the env var list for the runner container, optionally
+// injecting INSECURE_REGISTRIES from the RunnerConfigStore and emitting a K8s
+// Warning event when the module image matches an insecure registry.
+func (r *Reconciler) buildEnvVars(ctx context.Context, module *api.WasmModule, wasiConfig string) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		{Name: "IMAGE", Value: module.Spec.Image},
+		{Name: "WASI_CONFIG", Value: wasiConfig},
+	}
+
+	if r.RunnerConfigStore == nil {
+		return envVars
+	}
+
+	runnerCfg := r.RunnerConfigStore.GetRunnerConfig()
+	if len(runnerCfg.InsecureRegistries) == 0 {
+		return envVars
+	}
+
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "INSECURE_REGISTRIES",
+		Value: strings.Join(runnerCfg.InsecureRegistries, ","),
+	})
+
+	if MatchesInsecureRegistry(module.Spec.Image, runnerCfg.InsecureRegistries) {
+		controller.GetEventRecorder(ctx).Eventf(
+			module,
+			corev1.EventTypeWarning,
+			"InsecureRegistry",
+			"Image %q will be fetched over plain HTTP (matched insecure registry)",
+			module.Spec.Image,
+		)
+	}
+
+	return envVars
+}
+
 func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) (*servingv1.Service, error) {
 	log := logging.FromContext(ctx)
 
@@ -151,44 +187,10 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 		return nil, fmt.Errorf("failed to build runner config: %w", err)
 	}
 
-	// Prepare environment variables
-	envVars := []corev1.EnvVar{
-		{
-			Name:  "IMAGE",
-			Value: module.Spec.Image,
-		},
-		{
-			Name:  "WASI_CONFIG",
-			Value: wasiConfig,
-		},
-	}
-
-	// Inject INSECURE_REGISTRIES env var if configured
-	if r.RunnerConfigStore != nil {
-		runnerCfg := r.RunnerConfigStore.GetRunnerConfig()
-		if len(runnerCfg.InsecureRegistries) > 0 {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  "INSECURE_REGISTRIES",
-				Value: strings.Join(runnerCfg.InsecureRegistries, ","),
-			})
-
-			// Emit K8s Warning event if the module's image matches an insecure registry
-			if MatchesInsecureRegistry(module.Spec.Image, runnerCfg.InsecureRegistries) {
-				controller.GetEventRecorder(ctx).Eventf(
-					module,
-					corev1.EventTypeWarning,
-					"InsecureRegistry",
-					"Image %q will be fetched over plain HTTP (matched insecure registry)",
-					module.Spec.Image,
-				)
-			}
-		}
-	}
-
 	// Build container spec
 	container := corev1.Container{
 		Image:        DefaultRunnerImage,
-		Env:          envVars,
+		Env:          r.buildEnvVars(ctx, module, wasiConfig),
 		VolumeMounts: module.Spec.VolumeMounts,
 		Resources:    module.Spec.Resources,
 	}

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	api "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
 	apireconciler "github.com/cardil/knative-serving-wasm/pkg/client/injection/reconciler/wasm/v1alpha1/wasmmodule"
@@ -29,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
@@ -67,6 +69,9 @@ type Reconciler struct {
 
 	// Client is used to create the service
 	Client servingv1client.ServingV1Interface
+
+	// RunnerConfigStore holds the runner configuration from config-runner ConfigMap.
+	RunnerConfigStore *RunnerConfigStore
 }
 
 // Check that our Reconciler implements Interface.
@@ -151,6 +156,28 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 		},
 	}
 
+	// Inject INSECURE_REGISTRIES env var if configured
+	if r.RunnerConfigStore != nil {
+		runnerCfg := r.RunnerConfigStore.GetRunnerConfig()
+		if len(runnerCfg.InsecureRegistries) > 0 {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "INSECURE_REGISTRIES",
+				Value: strings.Join(runnerCfg.InsecureRegistries, ","),
+			})
+
+			// Emit K8s Warning event if the module's image matches an insecure registry
+			if MatchesInsecureRegistry(module.Spec.Image, runnerCfg.InsecureRegistries) {
+				controller.GetEventRecorder(ctx).Eventf(
+					module,
+					corev1.EventTypeWarning,
+					"InsecureRegistry",
+					"Image %q will be fetched over plain HTTP (matched insecure registry)",
+					module.Spec.Image,
+				)
+			}
+		}
+	}
+
 	// Build container spec
 	container := corev1.Container{
 		Image:        DefaultRunnerImage,
@@ -192,6 +219,41 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 	}
 
 	return srv, err
+}
+
+// MatchesInsecureRegistry reports whether the OCI image reference's registry
+// host matches any entry in the insecure registries list.
+func MatchesInsecureRegistry(image string, insecureRegistries []string) bool {
+	// Strip oci:// prefix if present
+	image = strings.TrimPrefix(image, "oci://")
+
+	// Extract registry host from image reference.
+	// OCI image references have the form: [host[:port]/]path[:tag][@digest]
+	// The registry host is the part before the first slash, if it contains a dot or colon.
+	var registryHost string
+
+	slash := strings.Index(image, "/")
+	if slash < 0 {
+		// No slash: image is something like "ubuntu:latest" — uses docker.io
+		return false
+	}
+
+	firstPart := image[:slash]
+	// If the first part contains a dot or colon, it's a registry host
+	if strings.ContainsAny(firstPart, ".:") {
+		registryHost = firstPart
+	} else {
+		// No explicit registry host (e.g., "library/ubuntu") — uses docker.io
+		return false
+	}
+
+	for _, reg := range insecureRegistries {
+		if strings.EqualFold(reg, registryHost) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // RunnerWasiConfig represents the WASI configuration passed to the runner.

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -248,8 +248,9 @@ func MatchesInsecureRegistry(image string, insecureRegistries []string) bool {
 	}
 
 	firstPart := image[:slash]
-	// If the first part contains a dot or colon, it's a registry host
-	if strings.ContainsAny(firstPart, ".:") {
+	// If the first part contains a dot or colon, or is "localhost", it's a registry host.
+	// "localhost" is a well-known exception that Docker/containerd also treat specially.
+	if strings.ContainsAny(firstPart, ".:") || strings.EqualFold(firstPart, "localhost") {
 		registryHost = firstPart
 	} else {
 		// No explicit registry host (e.g., "library/ubuntu") — uses docker.io

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -233,8 +233,10 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 // MatchesInsecureRegistry reports whether the OCI image reference's registry
 // host matches any entry in the insecure registries list.
 func MatchesInsecureRegistry(image string, insecureRegistries []string) bool {
-	// Strip oci:// prefix if present
-	image = strings.TrimPrefix(image, "oci://")
+	// Strip oci:// prefix if present (case-insensitive)
+	if len(image) >= len("oci://") && strings.EqualFold(image[:len("oci://")], "oci://") {
+		image = image[len("oci://"):]
+	}
 
 	// Extract registry host from image reference.
 	// OCI image references have the form: [host[:port]/]path[:tag][@digest]

--- a/pkg/reconciler/wasmmodule/wasmmodule_test.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule_test.go
@@ -17,14 +17,19 @@ limitations under the License.
 package wasmmodule_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	api "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
 	"github.com/cardil/knative-serving-wasm/pkg/reconciler/wasmmodule"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/controller"
+	servingfake "knative.dev/serving/pkg/client/clientset/versioned/fake"
 )
 
 // TestBuildRunnerConfigMatchesGolden verifies that the JSON produced by
@@ -99,5 +104,162 @@ func assertJSONEqual(t *testing.T, got, want string) {
 
 	if string(gotJSON) != string(wantJSON) {
 		t.Errorf("BuildRunnerConfig output does not match golden.\ngot:\n%s\n\nwant:\n%s", gotJSON, wantJSON)
+	}
+}
+
+// buildRunnerConfigStore seeds a RunnerConfigStore with the given insecure registries.
+func buildRunnerConfigStore(registries []string) *wasmmodule.RunnerConfigStore {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: wasmmodule.RunnerConfigName},
+		Data:       map[string]string{},
+	}
+
+	if len(registries) > 0 {
+		var sb strings.Builder
+		for _, r := range registries {
+			sb.WriteString("- ")
+			sb.WriteString(r)
+			sb.WriteString("\n")
+		}
+
+		cm.Data["insecure-registries"] = sb.String()
+	}
+
+	store := wasmmodule.NewRunnerConfigStore(noopLogger{})
+	store.OnConfigChanged(cm)
+
+	return store
+}
+
+// noopLogger satisfies configmap.Logger for unit tests.
+type noopLogger struct{}
+
+func (noopLogger) Debugf(string, ...interface{}) {}
+func (noopLogger) Infof(string, ...interface{})  {}
+func (noopLogger) Errorf(string, ...interface{}) {}
+func (noopLogger) Fatalf(string, ...interface{}) {}
+
+// buildReconcilerCtx returns a context with a fake event recorder attached.
+func buildReconcilerCtx() context.Context {
+	return controller.WithEventRecorder(context.Background(), record.NewFakeRecorder(100))
+}
+
+// TestCreateService_InsecureRegistries_Injected checks that INSECURE_REGISTRIES
+// env var is set on the runner container when the config store has entries.
+func TestCreateService_InsecureRegistries_Injected(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+
+	const moduleName = "my-wasm"
+
+	fakeClient := servingfake.NewSimpleClientset()
+	store := buildRunnerConfigStore([]string{"registry.local:5000", "my-reg.internal:5000"})
+
+	r := &wasmmodule.Reconciler{
+		Tracker:           fakeTracker{},
+		ServiceLister:     buildServiceLister(),
+		Client:            fakeClient.ServingV1(),
+		RunnerConfigStore: store,
+	}
+
+	module := &api.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      moduleName,
+			Namespace: ns,
+		},
+		Spec: api.WasmModuleSpec{
+			Image: "ghcr.io/example/module:latest",
+		},
+	}
+	module.Status.InitializeConditions()
+
+	ctx := buildReconcilerCtx()
+	if err := r.ReconcileKind(ctx, module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	svcs, err := fakeClient.ServingV1().Services(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+
+	if len(svcs.Items) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(svcs.Items))
+	}
+
+	containers := svcs.Items[0].Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	envMap := make(map[string]string)
+	for _, e := range containers[0].Env {
+		envMap[e.Name] = e.Value
+	}
+
+	got, ok := envMap["INSECURE_REGISTRIES"]
+	if !ok {
+		t.Fatal("expected INSECURE_REGISTRIES env var to be set")
+	}
+
+	if got != "registry.local:5000,my-reg.internal:5000" {
+		t.Errorf("INSECURE_REGISTRIES = %q, want %q", got, "registry.local:5000,my-reg.internal:5000")
+	}
+}
+
+// TestCreateService_InsecureRegistries_Absent checks that INSECURE_REGISTRIES
+// is NOT set when the config store has no entries.
+func TestCreateService_InsecureRegistries_Absent(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+
+	const moduleName = "my-wasm-clean"
+
+	fakeClient := servingfake.NewSimpleClientset()
+	store := buildRunnerConfigStore(nil)
+
+	r := &wasmmodule.Reconciler{
+		Tracker:           fakeTracker{},
+		ServiceLister:     buildServiceLister(),
+		Client:            fakeClient.ServingV1(),
+		RunnerConfigStore: store,
+	}
+
+	module := &api.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      moduleName,
+			Namespace: ns,
+		},
+		Spec: api.WasmModuleSpec{
+			Image: "ghcr.io/example/module:latest",
+		},
+	}
+	module.Status.InitializeConditions()
+
+	ctx := buildReconcilerCtx()
+	if err := r.ReconcileKind(ctx, module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	svcs, err := fakeClient.ServingV1().Services(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+
+	if len(svcs.Items) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(svcs.Items))
+	}
+
+	containers := svcs.Items[0].Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	for _, e := range containers[0].Env {
+		if e.Name == "INSECURE_REGISTRIES" {
+			t.Errorf("expected INSECURE_REGISTRIES to be absent, but got %q", e.Value)
+		}
 	}
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -61,9 +61,20 @@ async fn main() -> Result<()> {
         env::var("IMAGE")?
     };
 
+    // Read and parse INSECURE_REGISTRIES env var (comma-separated host[:port])
+    let insecure_registries: Vec<String> = env::var("INSECURE_REGISTRIES")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !insecure_registries.is_empty() {
+        println!("Insecure registries configured: {:?}", insecure_registries);
+    }
+
     // Fetch and decode the Wasm in OCI image
     println!("Fetching WASM module from: {}", imgname);
-    let wasm = oci::fetch_oci_image(&imgname).await?;
+    let wasm = oci::fetch_oci_image(&imgname, &insecure_registries).await?;
     println!("WASM module fetched successfully ({} bytes)", wasm.len());
 
     // Compile the component on the command line to machine code

--- a/runner/src/oci.rs
+++ b/runner/src/oci.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::{Error, Result};
+use oci_distribution::client::{ClientConfig, ClientProtocol};
 use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::{Client, Reference};
 
@@ -29,11 +30,22 @@ fn bad_num_of_layers_err() -> Error {
 /// # Arguments
 /// * `imgname` - The OCI image reference (e.g., "ghcr.io/example/module:latest")
 ///              Can also include the "oci://" prefix which will be stripped.
+/// * `insecure_registries` - List of registry hostnames (host[:port]) that should
+///                           be accessed over plain HTTP instead of HTTPS.
 ///
 /// # Returns
 /// The WASM module binary data
-pub async fn fetch_oci_image(imgname: &str) -> Result<Vec<u8>> {
-    let oci = Client::default();
+pub async fn fetch_oci_image(imgname: &str, insecure_registries: &[String]) -> Result<Vec<u8>> {
+    let protocol = if insecure_registries.is_empty() {
+        ClientProtocol::Https
+    } else {
+        ClientProtocol::HttpsExcept(insecure_registries.to_vec())
+    };
+    let config = ClientConfig {
+        protocol,
+        ..ClientConfig::default()
+    };
+    let oci = Client::new(config);
     // Strip the oci:// prefix if present (used by Knative/WASI conventions)
     let imgname = imgname.strip_prefix("oci://").unwrap_or(imgname);
     let imgref: Reference = imgname.parse()?;
@@ -54,4 +66,59 @@ pub async fn fetch_oci_image(imgname: &str) -> Result<Vec<u8>> {
     let wasm = image.layers.first().ok_or(bad_num_of_layers_err())?;
 
     Ok(wasm.data.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_protocol_empty_list_uses_https() {
+        // When insecure_registries is empty, we should use ClientProtocol::Https
+        let insecure: Vec<String> = vec![];
+        let protocol = if insecure.is_empty() {
+            ClientProtocol::Https
+        } else {
+            ClientProtocol::HttpsExcept(insecure.clone())
+        };
+        // Verify it's the Https variant by checking it's not HttpsExcept
+        assert!(matches!(protocol, ClientProtocol::Https));
+    }
+
+    #[test]
+    fn test_client_protocol_single_entry_uses_https_except() {
+        let insecure = vec!["registry.local:5000".to_string()];
+        let protocol = if insecure.is_empty() {
+            ClientProtocol::Https
+        } else {
+            ClientProtocol::HttpsExcept(insecure.clone())
+        };
+        match protocol {
+            ClientProtocol::HttpsExcept(entries) => {
+                assert_eq!(entries, vec!["registry.local:5000"]);
+            }
+            _ => panic!("expected HttpsExcept variant"),
+        }
+    }
+
+    #[test]
+    fn test_client_protocol_multiple_entries_uses_https_except() {
+        let insecure = vec![
+            "registry.local:5000".to_string(),
+            "my-registry.internal:5000".to_string(),
+        ];
+        let protocol = if insecure.is_empty() {
+            ClientProtocol::Https
+        } else {
+            ClientProtocol::HttpsExcept(insecure.clone())
+        };
+        match protocol {
+            ClientProtocol::HttpsExcept(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert!(entries.contains(&"registry.local:5000".to_string()));
+                assert!(entries.contains(&"my-registry.internal:5000".to_string()));
+            }
+            _ => panic!("expected HttpsExcept variant"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #18

Allow the WASM runner to pull modules from plain-HTTP OCI registries, configured via a `config-runner` ConfigMap and propagated as `INSECURE_REGISTRIES` env var into runner pods.

## Changes

### Runner (Rust)
- `runner/src/oci.rs`: `fetch_oci_image` accepts `insecure_registries: &[String]`; uses `ClientProtocol::HttpsExcept` when non-empty, `ClientProtocol::Https` otherwise
- `runner/src/main.rs`: reads/parses `INSECURE_REGISTRIES` env var (comma-separated), logs when non-empty, passes to `fetch_oci_image`

### Controller (Go)
- `config/config-runner.yaml`: new `config-runner` ConfigMap with `insecure-registries` key
- `pkg/reconciler/wasmmodule/runner_config.go`: `RunnerConfig` struct, YAML parser, `RunnerConfigStore` (hot-reloadable via Knative `configmap.Watcher`)
- `pkg/reconciler/wasmmodule/controller.go`: wire `RunnerConfigStore` with watcher
- `pkg/reconciler/wasmmodule/wasmmodule.go`: inject `INSECURE_REGISTRIES` env var; emit K8s `Warning` event when image matches insecure registry; `MatchesInsecureRegistry` helper

### Tests
- `runner_config_test.go`: ConfigMap parsing (empty, single, multiple, malformed YAML, host matching)
- `wasmmodule_test.go`: env var injected when store has entries; absent when store is empty

## Verification
- `cargo check` ✅
- `golangci-lint run` ✅ (0 issues)
- `go test ./...` ✅ (18 tests pass)

Assisted-by: 🤖 Claude Sonnet 4.6


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for pulling WASM modules from plain-HTTP OCI registries via `INSECURE_REGISTRIES` from the new `config-runner` ConfigMap. The controller injects the env var, warns on insecure pulls, and the runner allows HTTP for matching registries, including `localhost`.

- **New Features**
  - New `config-runner` ConfigMap with `insecure-registries` YAML list; hot-reloaded via `RunnerConfigStore`.
  - Controller injects `INSECURE_REGISTRIES` into runner pods and emits a K8s Warning when the image matches an insecure registry.
  - Runner reads `INSECURE_REGISTRIES` and uses `ClientProtocol::HttpsExcept` to allow plain-HTTP pulls for listed registries.
  - Registry matching treats `localhost` as a registry host and strips the `oci://` prefix case-insensitively (tests added).

- **Migration**
  - Default behavior stays HTTPS-only.
  - To enable, set `insecure-registries` (YAML list of host[:port]) in the `config-runner` ConfigMap; updates take effect without restarts.
  - Use only for development; plain HTTP is not secure.

<sup>Written for commit a9b99b81af91ed27a7443f7ceb60b25cf74b894c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ConfigMap-driven configuration for insecure container registries (YAML list).
  * Runner reads INSECURE_REGISTRIES and allows plain-HTTP pulls for listed registries.
  * Reconciler injects INSECURE_REGISTRIES into runtime environments and emits warnings when an image is pulled from a configured insecure registry.
  * Image matching supports common image reference formats (including oci://).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->