### PR TITLE
[release-0.2] Implement Service update on WasmModule spec changes

### DIFF
--- a/pkg/reconciler/wasmmodule/reconciler_test.go
+++ b/pkg/reconciler/wasmmodule/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/tracker"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	servingfake "knative.dev/serving/pkg/client/clientset/versioned/fake"
 	servingv1listers "knative.dev/serving/pkg/client/listers/serving/v1"
 )
 
@@ -170,10 +171,12 @@ func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
 			const moduleName = "my-wasm"
 
 			svc := ksvcWithConfigFailed(ns, moduleName, tt.svcReason, tt.svcMessage)
+			fakeClient := servingfake.NewSimpleClientset(svc)
 
 			r := &wasmmodule.Reconciler{
 				Tracker:       fakeTracker{},
 				ServiceLister: buildServiceLister(svc),
+				Client:        fakeClient.ServingV1(),
 			}
 
 			module := &api.WasmModule{
@@ -200,10 +203,12 @@ func TestReconcileKind_TransientNotReady(t *testing.T) {
 	const moduleName = "my-wasm"
 
 	svc := ksvcWithReadyUnknown(ns, moduleName)
+	fakeClient := servingfake.NewSimpleClientset(svc)
 
 	r := &wasmmodule.Reconciler{
 		Tracker:       fakeTracker{},
 		ServiceLister: buildServiceLister(svc),
+		Client:        fakeClient.ServingV1(),
 	}
 
 	module := &api.WasmModule{

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -291,12 +291,6 @@ func (r *Reconciler) updateService(
 
 	serviceName := module.Name
 
-	if r.Client == nil {
-		log.Errorf("Cannot update service %s: client is nil", serviceName)
-
-		return existing, nil
-	}
-
 	desired, err := r.buildDesiredService(ctx, module)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -26,6 +26,7 @@ import (
 	api "github.com/cardil/knative-serving-wasm/pkg/apis/wasm/v1alpha1"
 	apireconciler "github.com/cardil/knative-serving-wasm/pkg/client/injection/reconciler/wasm/v1alpha1/wasmmodule"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -95,48 +96,88 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, module *api.WasmModule) 
 		return err
 	}
 
-	srv, err := r.ServiceLister.Services(module.Namespace).Get(serviceName)
-
-	if apierrs.IsNotFound(err) {
-		log.Info("Service does not exist. Creating: ", serviceName)
-
-		if srv, err = r.createService(ctx, module); err != nil {
-			module.Status.MarkServiceUnavailable(serviceName)
-
-			return err
-		}
-	} else if err != nil {
-		log.Errorf("Error reconciling service %s: %v", serviceName, err)
-
+	srv, err := r.reconcileService(ctx, module)
+	if err != nil {
 		return err
 	}
 
-	// Only mark ready when the underlying Service is ready
-	// This ensures pods are running and Kourier has the route before tests can access it
+	r.syncModuleStatus(ctx, module, srv)
+
+	return nil
+}
+
+// reconcileService gets the existing Knative Service for the module, creating or
+// updating it as needed, and returns the current state of the Service.
+func (r *Reconciler) reconcileService(
+	ctx context.Context, module *api.WasmModule,
+) (*servingv1.Service, error) {
+	log := logging.FromContext(ctx)
+	serviceName := module.Name
+
+	existing, err := r.ServiceLister.Services(module.Namespace).Get(serviceName)
+
+	switch {
+	case apierrs.IsNotFound(err):
+		log.Info("Service does not exist. Creating: ", serviceName)
+
+		srv, createErr := r.createService(ctx, module)
+		if createErr != nil {
+			module.Status.MarkServiceUnavailable(serviceName)
+
+			return nil, createErr
+		}
+
+		return srv, nil
+
+	case err != nil:
+		log.Errorf("Error reconciling service %s: %v", serviceName, err)
+
+		return nil, err
+
+	default:
+		srv, updateErr := r.updateService(ctx, module, existing)
+		if updateErr != nil {
+			module.Status.MarkServiceUnavailable(serviceName)
+
+			return nil, updateErr
+		}
+
+		return srv, nil
+	}
+}
+
+// syncModuleStatus updates the WasmModule status based on the Knative Service readiness.
+func (r *Reconciler) syncModuleStatus(
+	_ context.Context, module *api.WasmModule, srv *servingv1.Service,
+) {
+	serviceName := module.Name
+
+	// Only mark ready when the underlying Service is ready.
+	// This ensures pods are running and Kourier has the route before tests can access it.
 	readyCondition := srv.Status.GetCondition(apis.ConditionReady)
 	if readyCondition != nil && readyCondition.IsTrue() {
 		module.Status.MarkServiceAvailable()
 
-		// Use the external URL (srv.Status.URL) instead of internal address (srv.Status.Address)
+		// Use the external URL (srv.Status.URL) instead of internal address (srv.Status.Address).
 		// The external URL works with the Knative ingress (e.g., Kourier) and follows
-		// the configured domain (e.g., example.com for "No DNS" mode on Kind clusters)
+		// the configured domain (e.g., example.com for "No DNS" mode on Kind clusters).
 		if srv.Status.URL != nil {
 			module.Status.Address = &duckv1.Addressable{
 				URL: srv.Status.URL,
 			}
 		}
-	} else {
-		// Check for a terminal Configuration failure (e.g. RevisionFailed, ContainerMissing)
-		// so that clients can distinguish transient "not ready yet" from permanent failures.
-		cfgCond := srv.Status.GetCondition(servingv1.ConfigurationConditionReady)
-		if cfgCond != nil && cfgCond.IsFalse() {
-			module.Status.MarkServiceFailed(cfgCond.Reason, cfgCond.Message)
-		} else {
-			module.Status.MarkServiceUnavailable(serviceName)
-		}
+
+		return
 	}
 
-	return nil
+	// Check for a terminal Configuration failure (e.g. RevisionFailed, ContainerMissing)
+	// so that clients can distinguish transient "not ready yet" from permanent failures.
+	cfgCond := srv.Status.GetCondition(servingv1.ConfigurationConditionReady)
+	if cfgCond != nil && cfgCond.IsFalse() {
+		module.Status.MarkServiceFailed(cfgCond.Reason, cfgCond.Message)
+	} else {
+		module.Status.MarkServiceUnavailable(serviceName)
+	}
 }
 
 // buildEnvVars builds the env var list for the runner container, optionally
@@ -175,10 +216,8 @@ func (r *Reconciler) buildEnvVars(ctx context.Context, module *api.WasmModule, w
 	return envVars
 }
 
-func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) (*servingv1.Service, error) {
-	log := logging.FromContext(ctx)
-
-	// Use metadata.name as service name
+// buildDesiredService constructs the desired Knative Service for the given WasmModule.
+func (r *Reconciler) buildDesiredService(ctx context.Context, module *api.WasmModule) (*servingv1.Service, error) {
 	serviceName := module.Name
 
 	// Build WASI config for the runner
@@ -200,7 +239,7 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 		container.ImagePullPolicy = corev1.PullPolicy(DefaultImagePullPolicy)
 	}
 
-	srv, err := r.Client.Services(module.Namespace).Create(ctx, &servingv1.Service{
+	return &servingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        serviceName,
 			Namespace:   module.Namespace,
@@ -222,9 +261,60 @@ func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) 
 				},
 			},
 		},
-	}, metav1.CreateOptions{})
+	}, nil
+}
+
+func (r *Reconciler) createService(ctx context.Context, module *api.WasmModule) (*servingv1.Service, error) {
+	log := logging.FromContext(ctx)
+
+	serviceName := module.Name
+
+	desired, err := r.buildDesiredService(ctx, module)
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := r.Client.Services(module.Namespace).Create(ctx, desired, metav1.CreateOptions{})
 	if err != nil {
 		log.Errorf("Error creating kservice %s: %v", serviceName, err)
+	}
+
+	return srv, err
+}
+
+// updateService compares the desired Service spec with the existing one and
+// updates the existing Service if the specs differ.
+func (r *Reconciler) updateService(
+	ctx context.Context, module *api.WasmModule, existing *servingv1.Service,
+) (*servingv1.Service, error) {
+	log := logging.FromContext(ctx)
+
+	serviceName := module.Name
+
+	if r.Client == nil {
+		log.Errorf("Cannot update service %s: client is nil", serviceName)
+
+		return existing, nil
+	}
+
+	desired, err := r.buildDesiredService(ctx, module)
+	if err != nil {
+		return nil, err
+	}
+
+	if equality.Semantic.DeepEqual(existing.Spec.Template, desired.Spec.Template) {
+		return existing, nil
+	}
+
+	log.Infof("Service spec changed, updating: %s", serviceName)
+
+	// Copy the desired template onto the existing object to preserve metadata (resourceVersion etc.)
+	updated := existing.DeepCopy()
+	updated.Spec.Template = desired.Spec.Template
+
+	srv, err := r.Client.Services(module.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		log.Errorf("Error updating kservice %s: %v", serviceName, err)
 	}
 
 	return srv, err

--- a/pkg/reconciler/wasmmodule/wasmmodule_test.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/controller"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingfake "knative.dev/serving/pkg/client/clientset/versioned/fake"
 )
 
@@ -260,6 +261,169 @@ func TestCreateService_InsecureRegistries_Absent(t *testing.T) {
 	for _, e := range containers[0].Env {
 		if e.Name == "INSECURE_REGISTRIES" {
 			t.Errorf("expected INSECURE_REGISTRIES to be absent, but got %q", e.Value)
+		}
+	}
+}
+
+// buildOldService creates a fake Knative Service with the given old image env var.
+func buildOldService(ns, name, oldImage string) *servingv1.Service {
+	return &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+		Spec: servingv1.ServiceSpec{
+			ConfigurationSpec: servingv1.ConfigurationSpec{
+				Template: servingv1.RevisionTemplateSpec{
+					Spec: servingv1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: wasmmodule.DefaultRunnerImage,
+									Env: []corev1.EnvVar{
+										{Name: "IMAGE", Value: oldImage},
+										{Name: "WASI_CONFIG", Value: "{}"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// getEnvMap extracts env vars from the first container of a Service as a map.
+func getEnvMap(t *testing.T, svc *servingv1.Service) map[string]string {
+	t.Helper()
+
+	containers := svc.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		t.Fatal("expected at least one container")
+	}
+
+	envMap := make(map[string]string)
+	for _, e := range containers[0].Env {
+		envMap[e.Name] = e.Value
+	}
+
+	return envMap
+}
+
+// TestUpdateService_SpecChanged verifies that when a WasmModule spec changes
+// (e.g. Image field), the reconciler updates the existing Knative Service.
+func TestUpdateService_SpecChanged(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+
+	const moduleName = "my-wasm-update"
+
+	// Seed the fake client with an existing Service that has the old IMAGE env var.
+	existingSvc := buildOldService(ns, moduleName, "example.com/old-image:v1")
+	fakeClient := servingfake.NewSimpleClientset(existingSvc)
+
+	r := &wasmmodule.Reconciler{
+		Tracker:       fakeTracker{},
+		ServiceLister: buildServiceLister(existingSvc),
+		Client:        fakeClient.ServingV1(),
+	}
+
+	// Module spec now references a new image.
+	module := &api.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: ns},
+		Spec:       api.WasmModuleSpec{Image: "example.com/new-image:v2"},
+	}
+	module.Status.InitializeConditions()
+
+	ctx := buildReconcilerCtx()
+	if err := r.ReconcileKind(ctx, module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	// Verify the Service was updated with the new image in the IMAGE env var.
+	svc, err := fakeClient.ServingV1().Services(ns).Get(ctx, moduleName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get service: %v", err)
+	}
+
+	envMap := getEnvMap(t, svc)
+
+	if got := envMap["IMAGE"]; got != "example.com/new-image:v2" {
+		t.Errorf("IMAGE env var = %q, want %q", got, "example.com/new-image:v2")
+	}
+}
+
+// buildMatchingService builds a Knative Service whose spec exactly matches what the reconciler
+// would produce for the given WasmModule (i.e., no drift).
+func buildMatchingService(t *testing.T, ns, name string, module *api.WasmModule) *servingv1.Service {
+	t.Helper()
+
+	wasiConfig, err := wasmmodule.BuildRunnerConfig(module)
+	if err != nil {
+		t.Fatalf("BuildRunnerConfig: %v", err)
+	}
+
+	return &servingv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, ResourceVersion: "1"},
+		Spec: servingv1.ServiceSpec{
+			ConfigurationSpec: servingv1.ConfigurationSpec{
+				Template: servingv1.RevisionTemplateSpec{
+					Spec: servingv1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: wasmmodule.DefaultRunnerImage,
+									Env: []corev1.EnvVar{
+										{Name: "IMAGE", Value: module.Spec.Image},
+										{Name: "WASI_CONFIG", Value: wasiConfig},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestUpdateService_SpecUnchanged verifies that when the WasmModule spec hasn't
+// changed, the reconciler does NOT call Update (no unnecessary API calls).
+func TestUpdateService_SpecUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+
+	const moduleName = "my-wasm-noop"
+
+	module := &api.WasmModule{
+		ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: ns},
+		Spec:       api.WasmModuleSpec{Image: "example.com/img:latest"},
+	}
+	module.Status.InitializeConditions()
+
+	ctx := buildReconcilerCtx()
+
+	existingSvc := buildMatchingService(t, ns, moduleName, module)
+	fakeClient := servingfake.NewSimpleClientset(existingSvc)
+
+	r := &wasmmodule.Reconciler{
+		Tracker:       fakeTracker{},
+		ServiceLister: buildServiceLister(existingSvc),
+		Client:        fakeClient.ServingV1(),
+	}
+
+	if err := r.ReconcileKind(ctx, module); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	// Inspect fake client actions to confirm Update was NOT called.
+	for _, a := range fakeClient.Actions() {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "services" {
+			t.Errorf("expected no Update call when spec is unchanged, but got one: %v", a)
 		}
 	}
 }


### PR DESCRIPTION
Cherry-pick of #22 onto `release-0.2`.

When WasmModule spec is updated, the reconciler now detects spec drift and updates the Knative Service accordingly.

Changes:
- Extract `buildDesiredService` from `createService`
- Add `updateService` with `equality.Semantic.DeepEqual` comparison
- Extract `reconcileService` and `syncModuleStatus` helpers
- Add unit tests for update and no-op paths

Fixes #10

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The reconciler now updates the Knative Service when a `WasmModule` spec changes, preventing drift. It also keeps module status in sync with Service readiness and uses the external URL.

- **New Features**
  - Detects spec drift with `equality.Semantic.DeepEqual`; updates Service template when changed, no-op otherwise.
  - Adds `reconcileService`, `buildDesiredService`, `updateService`, and `syncModuleStatus` to clarify create/update flow.
  - Adds unit tests for update/no-op paths; updates status-only tests to pass a `servingfake.NewSimpleClientset` after removing the nil client guard in `updateService`.

<sup>Written for commit 8b2a958e096655cebb0b5d97409bf507d5ba429a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

