### PR TITLE
Remove nil client guard; fix status-only tests to supply fake client

### DIFF
--- a/pkg/reconciler/wasmmodule/reconciler_test.go
+++ b/pkg/reconciler/wasmmodule/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/tracker"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	servingfake "knative.dev/serving/pkg/client/clientset/versioned/fake"
 	servingv1listers "knative.dev/serving/pkg/client/listers/serving/v1"
 )
 
@@ -170,10 +171,12 @@ func TestReconcileKind_TerminalConfigFailure(t *testing.T) {
 			const moduleName = "my-wasm"
 
 			svc := ksvcWithConfigFailed(ns, moduleName, tt.svcReason, tt.svcMessage)
+			fakeClient := servingfake.NewSimpleClientset(svc)
 
 			r := &wasmmodule.Reconciler{
 				Tracker:       fakeTracker{},
 				ServiceLister: buildServiceLister(svc),
+				Client:        fakeClient.ServingV1(),
 			}
 
 			module := &api.WasmModule{
@@ -200,10 +203,12 @@ func TestReconcileKind_TransientNotReady(t *testing.T) {
 	const moduleName = "my-wasm"
 
 	svc := ksvcWithReadyUnknown(ns, moduleName)
+	fakeClient := servingfake.NewSimpleClientset(svc)
 
 	r := &wasmmodule.Reconciler{
 		Tracker:       fakeTracker{},
 		ServiceLister: buildServiceLister(svc),
+		Client:        fakeClient.ServingV1(),
 	}
 
 	module := &api.WasmModule{

--- a/pkg/reconciler/wasmmodule/wasmmodule.go
+++ b/pkg/reconciler/wasmmodule/wasmmodule.go
@@ -291,12 +291,6 @@ func (r *Reconciler) updateService(
 
 	serviceName := module.Name
 
-	if r.Client == nil {
-		log.Errorf("Cannot update service %s: client is nil", serviceName)
-
-		return existing, nil
-	}
-
 	desired, err := r.buildDesiredService(ctx, module)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The nil-client guard in `updateService` was added to work around tests that omit `Client`. In production the field is always set via `svcclient.Get(ctx).ServingV1()` in `NewController`, so the guard is dead code.

Changes:
- Remove the `if r.Client == nil { return existing, nil }` guard from `updateService`
- Supply `servingfake.NewSimpleClientset` to `TestReconcileKind_TerminalConfigFailure` and `TestReconcileKind_TransientNotReady` (which test status propagation, not the client path)

Addresses review comment on #23 (backport of #22).

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the nil-client guard in updateService. Updated status-only reconciler tests to pass a `servingfake` Knative Serving client, matching production and preventing silent no-ops.

<sup>Written for commit aac472ce180c4aecfa040859262cb761fded311a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests to properly inject service dependencies into the reconciler.

* **Refactor**
  * Simplified internal validation logic by removing defensive checks, streamlining the service update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->